### PR TITLE
SpringBoot 버전업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.17'
-    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'org.springframework.boot' version '3.1.6'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '11'
+    sourceCompatibility = '17'
 }
 
 configurations {


### PR DESCRIPTION
- SpringBoot 2.X 지원 종료로 인해 버전업하기로 함
- Java 11 -> Java 17 / SpringBoot 2.7.17 -> SpringBoot 3.1.6