### PR TITLE
토큰 검증 에러 수정, 구단 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/service/MemberService.java
@@ -16,8 +16,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    private final JwtTokenProvider jwtTokenProvider;
-
     public Map<String, Object> login(String username, String password) {
         Member member = memberRepository.findByUsername(username).orElseThrow();
 
@@ -26,7 +24,7 @@ public class MemberService {
         }
 
         Map<String, Object> response = new HashMap<>();
-        response.put("token", jwtTokenProvider.createToken(member));
+        response.put("token", JwtTokenProvider.createToken(member));
 
         return response;
     }

--- a/src/main/java/com/example/baseballprediction/domain/team/controller/TeamController.java
+++ b/src/main/java/com/example/baseballprediction/domain/team/controller/TeamController.java
@@ -1,0 +1,30 @@
+package com.example.baseballprediction.domain.team.controller;
+
+import com.example.baseballprediction.domain.team.dto.TeamResponse;
+import com.example.baseballprediction.domain.team.service.TeamService;
+import com.example.baseballprediction.global.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.example.baseballprediction.domain.team.dto.TeamResponse.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @GetMapping("/teams")
+    public ResponseEntity<ApiResponse<List<TeamsDTO>>> teamList() {
+        List<TeamsDTO> teams = teamService.findTeams();
+
+        ApiResponse<List<TeamsDTO>> response = ApiResponse.success(teams);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/baseballprediction/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/example/baseballprediction/domain/team/dto/TeamResponse.java
@@ -1,0 +1,21 @@
+package com.example.baseballprediction.domain.team.dto;
+
+import com.example.baseballprediction.domain.team.entity.Team;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TeamResponse {
+    @Getter
+    @NoArgsConstructor
+    public static class TeamsDTO {
+        private int teamId;
+        private String teamName;
+        private String teamImageUrl;
+
+        public TeamsDTO(Team team) {
+            this.teamId = team.getId();
+            this.teamName = team.getName();
+            this.teamImageUrl = team.getLogoUrl();
+        }
+    }
+}

--- a/src/main/java/com/example/baseballprediction/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/baseballprediction/domain/team/service/TeamService.java
@@ -1,0 +1,23 @@
+package com.example.baseballprediction.domain.team.service;
+
+import com.example.baseballprediction.domain.team.dto.TeamResponse;
+import com.example.baseballprediction.domain.team.entity.Team;
+import com.example.baseballprediction.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.example.baseballprediction.domain.team.dto.TeamResponse.*;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+    private final TeamRepository teamRepository;
+
+    public List<TeamsDTO> findTeams() {
+        List<Team> teams = teamRepository.findAll();
+
+        return teams.stream().map(m -> new TeamsDTO(m)).toList();
+    }
+}

--- a/src/main/java/com/example/baseballprediction/global/security/auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/baseballprediction/global/security/auth/JwtTokenProvider.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.Base64;
 import java.util.Date;
 
 @Component
@@ -14,11 +15,14 @@ public class JwtTokenProvider {
     public static final Long EXP = 1000L * 60 * 60 * 24;
     public static final String TOKEN_PREFIX = "Bearer ";
     public static final String HEADER = "Authorization";
+    private static String secretKey;
 
     @Value("${my-env.jwt.key}")
-    private String secretKey;
+    public void setSecretKey(String secret) {
+        secretKey = Base64.getEncoder().encodeToString(secret.getBytes());
+    }
 
-    public Long getMemberIdFromToken(String token) {
+    public static Long getMemberIdFromToken(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
                 .parseClaimsJws(token)
@@ -26,7 +30,7 @@ public class JwtTokenProvider {
                 .get("id", Long.class);
     }
 
-    public String getNicknameFromToken(String token) {
+    public static String getNicknameFromToken(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
                 .parseClaimsJws(token)
@@ -34,7 +38,7 @@ public class JwtTokenProvider {
                 .get("nickname", String.class);
     }
 
-    public boolean validateToken(String token) {
+    public static boolean validateToken(String token) {
         try {
             Claims claims = Jwts.parser()
                     .setSigningKey(secretKey)
@@ -47,7 +51,7 @@ public class JwtTokenProvider {
         }
     }
 
-    public String createToken(Member member) {
+    public static String createToken(Member member) {
         Claims claims = Jwts.claims();
         claims.put("id", member.getId());
         claims.put("nickname", member.getNickname());

--- a/src/main/java/com/example/baseballprediction/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/baseballprediction/global/security/filter/JwtAuthenticationFilter.java
@@ -37,13 +37,13 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
 
         jwt = jwt.replace(JwtTokenProvider.TOKEN_PREFIX, "");
 
-        if (!jwtTokenProvider.validateToken(jwt)) {
+        if (!JwtTokenProvider.validateToken(jwt)) {
             filterChain.doFilter(request, response);
         }
 
         Member member = Member.builder()
-                .id(jwtTokenProvider.getMemberIdFromToken(jwt))
-                .nickname(jwtTokenProvider.getNicknameFromToken(jwt))
+                .id(JwtTokenProvider.getMemberIdFromToken(jwt))
+                .nickname(JwtTokenProvider.getNicknameFromToken(jwt))
                 .build();
 
         MemberDetails memberDetails = new MemberDetails(member);

--- a/src/main/java/com/example/baseballprediction/global/util/ApiResponse.java
+++ b/src/main/java/com/example/baseballprediction/global/util/ApiResponse.java
@@ -26,6 +26,10 @@ public class ApiResponse<T> {
         return new ApiResponse(HttpStatus.OK.value(), SUCCESS_MESSAGE, null);
     }
 
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), SUCCESS_MESSAGE, data);
+    }
+
     public static ApiResponse<?> createValidationFail(BindingResult bindingResult) {
         Map<String, String> errors = new HashMap<>();
 


### PR DESCRIPTION
1. 토큰 검증 에러 수정
  - validateToken() 메서드 동작 시, secretKey = null이여서 NPE 발생
  - 우선 JwtTokenProvider 클래스의 메서드들을 static으로 수정 및 JwtTokenProvider 의존성 주입 제거하여 static 메서드 사용하도록 수정함
2. 구단 조회 API 기능 구현
  - GET /teams URL 매핑
  - 모든 구단의 team.id, name, logo_url 조회하여 응답