### PR TITLE
월간 승리요정 댓글 작성 API 기능 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/controller/MonthlyFairyController.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/controller/MonthlyFairyController.java
@@ -4,15 +4,21 @@ import static com.example.baseballprediction.domain.monthlyfairy.dto.MonthlyFair
 import static com.example.baseballprediction.domain.reply.dto.ReplyResponse.*;
 
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.baseballprediction.domain.monthlyfairy.service.MonthlyFairyService;
+import com.example.baseballprediction.domain.reply.dto.ReplyRequest;
 import com.example.baseballprediction.domain.reply.service.ReplyService;
 import com.example.baseballprediction.global.constant.ReplyType;
+import com.example.baseballprediction.global.security.auth.MemberDetails;
 import com.example.baseballprediction.global.util.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -32,7 +38,7 @@ public class MonthlyFairyController {
 
 		return ResponseEntity.ok(response);
 	}
-	
+
 	@GetMapping("/replies")
 	public ResponseEntity<ApiResponse<Page<ReplyDTO>>> replyList(
 		@RequestParam(required = false, defaultValue = "0") int page,
@@ -47,5 +53,13 @@ public class MonthlyFairyController {
 		ApiResponse<Page<ReplyDTO>> response = ApiResponse.success(replies);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/reply")
+	public ResponseEntity<ApiResponse> replyAdd(@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody
+	ReplyRequest.ReplyDTO replyDTO) {
+		replyService.addReply(ReplyType.FAIRY, memberDetails.getUsername(), replyDTO.getContent());
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess());
 	}
 }

--- a/src/main/java/com/example/baseballprediction/global/util/ApiResponse.java
+++ b/src/main/java/com/example/baseballprediction/global/util/ApiResponse.java
@@ -1,17 +1,18 @@
 package com.example.baseballprediction.global.util;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,11 +24,15 @@ public class ApiResponse<T> {
     private T data;
 
     public static ApiResponse createSuccess() {
-        return new ApiResponse(HttpStatus.OK.value(), SUCCESS_MESSAGE, null);
+        return new ApiResponse(HttpStatus.CREATED.value(), SUCCESS_MESSAGE, null);
     }
 
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(HttpStatus.OK.value(), SUCCESS_MESSAGE, data);
+    }
+
+    public static ApiResponse successWithNoData() {
+        return new ApiResponse(HttpStatus.OK.value(), SUCCESS_MESSAGE, null);
     }
 
     public static ApiResponse<?> createValidationFail(BindingResult bindingResult) {
@@ -36,7 +41,7 @@ public class ApiResponse<T> {
         List<ObjectError> allErrors = bindingResult.getAllErrors();
         for (ObjectError error : allErrors) {
             if (error instanceof FieldError) {
-                errors.put(((FieldError) error).getField(), error.getDefaultMessage());
+                errors.put(((FieldError)error).getField(), error.getDefaultMessage());
             } else {
                 errors.put(error.getObjectName(), error.getDefaultMessage());
             }


### PR DESCRIPTION
closed #33

1. API 공통 응답 포맷 메서드 수정
  - 기존 createSuccess() 메서드 -> 200 OK 응답을 201 Created로 수정
  - 200 OK, data 없을 경우에 사용할 successWithNoData() 메서드 추가

2. API 구현
  - POST /statistics/reply 매핑
  - 201 Created 응답