### PR TITLE
월간 승리요정 댓글 좋아요 API 기능 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/controller/MonthlyFairyController.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/controller/MonthlyFairyController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.baseballprediction.domain.monthlyfairy.service.MonthlyFairyService;
 import com.example.baseballprediction.domain.reply.dto.ReplyRequest;
 import com.example.baseballprediction.domain.reply.service.ReplyService;
+import com.example.baseballprediction.domain.replylike.service.ReplyLikeService;
 import com.example.baseballprediction.global.constant.ReplyType;
 import com.example.baseballprediction.global.security.auth.MemberDetails;
 import com.example.baseballprediction.global.util.ApiResponse;
@@ -31,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class MonthlyFairyController {
 	private final MonthlyFairyService monthlyFairyService;
 	private final ReplyService replyService;
+	private final ReplyLikeService replyLikeService;
 
 	@GetMapping("")
 	public ResponseEntity<ApiResponse<StatisticsDTO>> monthlyFairyList() {
@@ -69,6 +71,15 @@ public class MonthlyFairyController {
 	public ResponseEntity<ApiResponse> replyRemove(@AuthenticationPrincipal MemberDetails memberDetails,
 		@PathVariable Long replyId) {
 		replyService.deleteReply(replyId, memberDetails.getUsername());
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	@PostMapping("/replies/{replyId}/like")
+	public ResponseEntity<ApiResponse> replyLikeAdd(@AuthenticationPrincipal MemberDetails memberDetails,
+		@PathVariable Long replyId) {
+
+		replyLikeService.saveReplyLike(memberDetails.getUsername(), replyId);
 
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}

--- a/src/main/java/com/example/baseballprediction/domain/replylike/entity/ReplyLike.java
+++ b/src/main/java/com/example/baseballprediction/domain/replylike/entity/ReplyLike.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 public class ReplyLike extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "reply_like")
+	@Column(name = "reply_like_id")
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
closed #35 

1. 댓글 좋아요 엔티티 id 컬럼 매핑 오류 수정
   - 컬럼명 reply_like -> reply_like_id

2. 월간 승리요정 댓글 좋아요 API 기능 구현
   - POST /statistics/replies/{replyId}/like 매핑