### PR TITLE
프로필 수정 API, 이미지 업로드 적용

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.baseballprediction.domain.member.dto.FairyProjection;
 import com.example.baseballprediction.domain.member.dto.ProfileProjection;
@@ -48,12 +50,13 @@ public class MemberController {
 	}
 
 	@PutMapping("/profile/details")
-	public ResponseEntity<ApiResponse<?>> detailsModify(@RequestBody DetailsDTO detailsDTO,
+	public ResponseEntity<ApiResponse<?>> detailsModify(@RequestPart("data") DetailsDTO detailsDTO,
+		@RequestPart(name = "profileImage", required = false) MultipartFile profileImage,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 
-		memberService.modifyDetails(memberDetails.getUsername(), detailsDTO);
+		memberService.modifyDetails(memberDetails.getUsername(), detailsDTO, profileImage);
 
-		return ResponseEntity.ok(ApiResponse.createSuccess());
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
 
 	@GetMapping("/profiles/{memberId}")

--- a/src/main/java/com/example/baseballprediction/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/dto/MemberRequest.java
@@ -4,24 +4,23 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class MemberRequest {
-    @Getter
-    @NoArgsConstructor
-    public static class LoginDTO {
-        private String username;
-        private String password;
-    }
+	@Getter
+	@NoArgsConstructor
+	public static class LoginDTO {
+		private String username;
+		private String password;
+	}
 
-    @Getter
-    @NoArgsConstructor
-    public static class LikeTeamDTO {
-        private Integer teamId;
-    }
+	@Getter
+	@NoArgsConstructor
+	public static class LikeTeamDTO {
+		private Integer teamId;
+	}
 
-    @Getter
-    @NoArgsConstructor
-    public static class DetailsDTO {
-        private String profileImageUrl;
-        private String nickname;
-        private String comment;
-    }
+	@Getter
+	@NoArgsConstructor
+	public static class DetailsDTO {
+		private String nickname;
+		private String comment;
+	}
 }

--- a/src/main/resources-env/prod/application.yml
+++ b/src/main/resources-env/prod/application.yml
@@ -24,6 +24,7 @@ cloud:
   aws:
     s3:
       bucket: ${S3.BUCKET}
+      domain: ${S3.DOMAIN}
     credentials:
       access-key: ${S3.ACCESSKEY}
       secret-key: ${S3.SECRETKEY}


### PR DESCRIPTION
closed #51 

- 기존 JSON 요청 방식 -> form-data 방식으로 변경
- 클라이언트가 전달한 프로필 이미지, S3에 업로드
- 업로드한 이미지 url은 member.profile_image_url에 저장
