### PR TITLE
마이페이지 요정 히스토리 조회 API 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import static com.example.baseballprediction.domain.member.dto.MemberResponse.*;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -86,4 +88,17 @@ public class MemberController {
 		return ResponseEntity.ok(response);
 	}
 
+	@GetMapping("/profile/history/votes")
+	public ResponseEntity<ApiResponse<Page<FairyHistoryDTO>>> fairyHistoryList(
+		@AuthenticationPrincipal MemberDetails memberDetails,
+		@RequestParam(required = false, defaultValue = "0") int page,
+		@RequestParam(required = false, defaultValue = "10") int list) {
+
+		Page<FairyHistoryDTO> fairyHistories = memberService.findFairyHistories(memberDetails.getMember().getId(), page,
+			list);
+
+		ApiResponse<Page<FairyHistoryDTO>> response = ApiResponse.success(fairyHistories);
+
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/dto/MemberResponse.java
@@ -1,8 +1,12 @@
 package com.example.baseballprediction.domain.member.dto;
 
 import com.example.baseballprediction.domain.member.entity.Member;
+import com.example.baseballprediction.domain.monthlyfairy.entity.MonthlyFairy;
+import com.example.baseballprediction.global.util.CustomDateUtil;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class MemberResponse {
 	@Getter
@@ -21,6 +25,23 @@ public class MemberResponse {
 			this.token = member.getToken();
 			this.teamName = member.getTeam().getName();
 			this.comment = member.getComment();
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class FairyHistoryDTO {
+		private String type;
+		private int rank;
+		private String comment;
+		private String historyDate;
+
+		public FairyHistoryDTO(Member member, MonthlyFairy monthlyFairy) {
+			this.type = monthlyFairy.getType().getName();
+			this.rank = monthlyFairy.getRank();
+			this.comment = member.getComment();
+			this.historyDate = CustomDateUtil.dateToString(monthlyFairy.getCreatedAt());
 		}
 	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/entity/MonthlyFairy.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/entity/MonthlyFairy.java
@@ -1,5 +1,6 @@
 package com.example.baseballprediction.domain.monthlyfairy.entity;
 
+import com.example.baseballprediction.domain.BaseEntity;
 import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.global.constant.FairyType;
 
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MonthlyFairy {
+public class MonthlyFairy extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "monthly_fairy_id")

--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/repository/MonthlyFairyRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/repository/MonthlyFairyRepository.java
@@ -2,7 +2,10 @@ package com.example.baseballprediction.domain.monthlyfairy.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.domain.monthlyfairy.entity.MonthlyFairy;
@@ -11,4 +14,7 @@ public interface MonthlyFairyRepository extends JpaRepository<MonthlyFairy, Long
 	List<MonthlyFairy> findByMonth(int month);
 
 	List<MonthlyFairy> findByMember(Member member);
+
+	@Query("SELECT m FROM MonthlyFairy m WHERE m.member = :member")
+	Page<MonthlyFairy> findByMemberToPage(Member member, Pageable pageable);
 }

--- a/src/main/java/com/example/baseballprediction/global/constant/FairyType.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/FairyType.java
@@ -1,5 +1,14 @@
 package com.example.baseballprediction.global.constant;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public enum FairyType {
-    WIN, LOSE;
+	WIN("승리요정"), LOSE("패배요정");
+
+	private String name;
 }

--- a/src/main/java/com/example/baseballprediction/global/util/CustomDateUtil.java
+++ b/src/main/java/com/example/baseballprediction/global/util/CustomDateUtil.java
@@ -1,11 +1,20 @@
 package com.example.baseballprediction.global.util;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class CustomDateUtil {
-    public static LocalDateTime toDateTime(String dateTime) {
+	public static LocalDateTime toDateTime(String dateTime) {
 
-        return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-    }
+		return LocalDateTime.parse(dateTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+	}
+
+	public static String dateToString(LocalDateTime dateTime) {
+		return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+	}
+
+	public static String dateToString(LocalDate date) {
+		return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+	}
 }

--- a/src/main/resources/h2/schema.sql
+++ b/src/main/resources/h2/schema.sql
@@ -89,6 +89,8 @@ create table monthly_fairy(
     fairy_rank int not null,
     vote_ratio int not null,
     member_id bigint not null,
+    created_at datetime not null default current_timestamp,
+    modified_at datetime,
 	foreign key(member_id) references member(member_id)
 )ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
closed #57 

- GET /profile/history/votes 매핑
- MonthlyFairy 엔티티에 BaseEntity 상속 추가
- 히스토리 조회 기능 구현