### PR TITLE
프로필, 월간 승리요정, 댓글, 댓글 좋아요 비즈니스 로직 예외처리

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/service/MonthlyFairyService.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/service/MonthlyFairyService.java
@@ -14,7 +14,9 @@ import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.domain.member.repository.MemberRepository;
 import com.example.baseballprediction.domain.monthlyfairy.entity.MonthlyFairy;
 import com.example.baseballprediction.domain.monthlyfairy.repository.MonthlyFairyRepository;
+import com.example.baseballprediction.global.constant.ErrorCode;
 import com.example.baseballprediction.global.constant.FairyType;
+import com.example.baseballprediction.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -50,7 +52,7 @@ public class MonthlyFairyService {
 
 	private void findFairycount(Member member) {
 		if (member == null) {
-			throw new RuntimeException("멤버를 찾을 수 없습니다.");
+			throw new NotFoundException(ErrorCode.MEMBER_NOT_FOUND);
 		}
 
 		List<MonthlyFairy> monthlyFairies = monthlyFairyRepository.findByMember(member);

--- a/src/main/java/com/example/baseballprediction/domain/reply/service/ReplyService.java
+++ b/src/main/java/com/example/baseballprediction/domain/reply/service/ReplyService.java
@@ -7,13 +7,18 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import com.example.baseballprediction.domain.game.dto.GameReplyDTO;
 import com.example.baseballprediction.domain.game.dto.GameReplyLikeProjection.GameListDTO;
 import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.domain.member.repository.MemberRepository;
 import com.example.baseballprediction.domain.reply.entity.Reply;
 import com.example.baseballprediction.domain.reply.repository.ReplyRepository;
+import com.example.baseballprediction.global.constant.ErrorCode;
 import com.example.baseballprediction.global.constant.ReplyType;
+import com.example.baseballprediction.global.error.exception.NotFoundException;
+import com.example.baseballprediction.global.error.exception.ReplyMemberInvalidException;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,35 +27,33 @@ import lombok.RequiredArgsConstructor;
 public class ReplyService {
 	private final ReplyRepository replyRepository;
 	private final MemberRepository memberRepository;
-	
+
 	@Transactional(readOnly = true)
 	public Page<ReplyDTO> findRepliesByType(ReplyType replyType, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
 
 		Page<Reply> repliesPage = replyRepository.findByType(replyType, pageable);
-		
+
 		Page<ReplyDTO> replies = repliesPage.map(m -> new ReplyDTO(m));
 
 		return replies;
 	}
-	
-	
-	
+
 	@Transactional(readOnly = true)
-	public Page<GameListDTO> findGameReplyLike(ReplyType replyType,int page, int size){
-		
+	public Page<GameListDTO> findGameReplyLike(ReplyType replyType, int page, int size) {
+
 		Pageable pageable = PageRequest.of(page, size);
-	
+
 		Page<GameReplyDTO> findGameAllReplyList = replyRepository.findReplyGame(replyType, pageable);
-		
+
 		Page<GameListDTO> replies = findGameAllReplyList.map(m -> new GameListDTO(m));
-		
+
 		return replies;
 	}
-	
-	
+
 	public void addReply(ReplyType replyType, String username, String content) {
-		Member member = memberRepository.findByUsername(username).orElseThrow();
+		Member member = memberRepository.findByUsername(username).orElseThrow(
+			() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
 		Reply reply = Reply.builder()
 			.member(member)
@@ -62,19 +65,16 @@ public class ReplyService {
 	}
 
 	public void deleteReply(Long replyId, String username) {
-		Member member = memberRepository.findByUsername(username).orElseThrow();
+		Member member = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
-		Reply reply = replyRepository.findById(replyId).orElseThrow();
+		Reply reply = replyRepository.findById(replyId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.REPLY_NOT_FOUND));
 
 		if (!reply.getMember().equals(member)) {
-			throw new RuntimeException("본인이 작성한 댓글만 삭제가 가능합니다.");
+			throw new ReplyMemberInvalidException();
 		}
 
 		replyRepository.delete(reply);
 	}
-
-
-
-	
-	
 }

--- a/src/main/java/com/example/baseballprediction/domain/replylike/repository/ReplyLikeRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/replylike/repository/ReplyLikeRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.domain.reply.entity.Reply;
 import com.example.baseballprediction.domain.replylike.entity.ReplyLike;
 
@@ -11,4 +12,6 @@ public interface ReplyLikeRepository extends JpaRepository<ReplyLike, Long> {
 	Long countByReply(Reply reply);
 
 	Optional<ReplyLike> findByReply(Reply reply);
+
+	Optional<ReplyLike> findByMemberAndReply(Member member, Reply reply);
 }

--- a/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
@@ -11,10 +11,12 @@ public enum ErrorCode {
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "로그인 후 이용해주세요."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
 
-	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다."),
+	MEMBER_NICKNAME_EXIST(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다."),
 	MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자 정보를 찾을 수 없습니다."),
+	TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 정보를 찾을 수 없습니다."),
 	REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글 정보를 찾을 수 없습니다."),
-	REPLY_MEMBER_INVALID(HttpStatus.FORBIDDEN, "본인이 작성한 댓글만 수정/삭제가 가능합니다.");
+	REPLY_MEMBER_INVALID(HttpStatus.FORBIDDEN, "본인이 작성한 댓글만 수정/삭제가 가능합니다."),
+	LOGIN_PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "로그인 후 이용해주세요."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
 
-	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다.");
+	DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다."),
+	MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자 정보를 찾을 수 없습니다."),
+	REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글 정보를 찾을 수 없습니다."),
+	REPLY_MEMBER_INVALID(HttpStatus.FORBIDDEN, "본인이 작성한 댓글만 수정/삭제가 가능합니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
@@ -15,8 +15,11 @@ public enum ErrorCode {
 	MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자 정보를 찾을 수 없습니다."),
 	TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 정보를 찾을 수 없습니다."),
 	REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글 정보를 찾을 수 없습니다."),
+	REPLY_LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "좋아요 정보를 찾을 수 없습니다."),
 	REPLY_MEMBER_INVALID(HttpStatus.FORBIDDEN, "본인이 작성한 댓글만 수정/삭제가 가능합니다."),
-	LOGIN_PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+	LOGIN_PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	REPLY_LIKE_MEMBER_INVALID(HttpStatus.FORBIDDEN, "본인이 누른 좋아요만 취소할 수 있습니다."),
+	REPLY_LIKE_DUPLICATED(HttpStatus.BAD_REQUEST, "좋아요는 한 번만 누를 수 있습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/baseballprediction/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/example/baseballprediction/global/error/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.example.baseballprediction.global.error.exception;
+
+import com.example.baseballprediction.global.constant.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+	public NotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/example/baseballprediction/global/error/exception/ReplyMemberInvalidException.java
+++ b/src/main/java/com/example/baseballprediction/global/error/exception/ReplyMemberInvalidException.java
@@ -1,0 +1,13 @@
+package com.example.baseballprediction.global.error.exception;
+
+import com.example.baseballprediction.global.constant.ErrorCode;
+
+public class ReplyMemberInvalidException extends BusinessException {
+	public ReplyMemberInvalidException() {
+		super(ErrorCode.REPLY_MEMBER_INVALID);
+	}
+
+	public ReplyMemberInvalidException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}


### PR DESCRIPTION
closed #78 

1. 사용자
  - 로그인 -> ID, 패스워드 불일치 예외처리
  - 좋아하는 팀 선택 -> 없는 팀 값 예외처리
  - 프로필 수정 -> 회원정보 못 찾을 때 예외처리
  - 프로필 수정 -> 닉네임 중복 예외처리
  - 프로필 조회 -> 회원정보 못 찾을 때 예외처리
  - 마이페이지 -> 회원정보 못 찾을 때 예외처리
2. 월간 승리요정
  - 프로필 조회 -> 멤버 찾을 수 없을 때 예외처리
3. 댓글
  - 댓글 작성 -> 멤버 찾을 수 없을 때 예외처리
  - 댓글 삭제 -> 멤버, 댓글 찾을 수 없을 때 예외처리
  - 댓글 삭제 -> 남이 작성한 댓글 삭제 시 예외처리
4. 댓글 좋아요
  - 좋아요 -> 멤버, 댓글 정보 없을 때 예외처리
  - 좋아요 -> 중복 발생 예외처리
  - 좋아요 건수 조회 -> 댓글 정보 없을 때 예외처리
  - 좋아요 취소 -> 멤버, 댓글, 좋아요 정보 없을 때 예외처리
  - 좋아요 취소 -> 남이 누른 좋아요 취소 예외처리
