### PR TITLE
Feat: 오늘의 승부예측 퍼센트 & 경기 스코어 api

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/game/dto/GameResponse.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/dto/GameResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import com.example.baseballprediction.domain.game.entity.Game;
+import com.example.baseballprediction.domain.gamevote.dto.GameVoteRatioDTO;
 import com.example.baseballprediction.domain.team.entity.Team;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -31,10 +32,10 @@ public class GameResponse {
 
 		private String status;
 
-		public GameDtoDaily(Game game, Team homeTeam, Team awayTeam) {
+		public GameDtoDaily(Game game, Team homeTeam, Team awayTeam,GameVoteRatioDTO gameVoteRatioDTO) {
 			this.gameId = game.getId();
-			this.homeTeam = new TeamDailyDTO(homeTeam);
-			this.awayTeam = new TeamDailyDTO(awayTeam);
+			this.homeTeam = new TeamDailyDTO(homeTeam, game.getHomeTeamScore(),gameVoteRatioDTO.getHomeTeamVoteRatio(),homeTeam.getId());
+			this.awayTeam = new TeamDailyDTO(awayTeam, game.getAwayTeamScore(),gameVoteRatioDTO.getAwayTeamVoteRatio(),awayTeam.getId());
 			this.gameTime = game.getStartedAt();
 			this.status = game.getStatus().toString();
 		}
@@ -45,9 +46,16 @@ public class GameResponse {
 	public static class TeamDailyDTO {
 
 		private String teamName;
+		private int score;
+		private int voteRatio;
+		private int id;
+		
 
-		public TeamDailyDTO(Team team) {
+		public TeamDailyDTO(Team team,int score, int voteRatio, int id) {
 			this.teamName = team.getShortName();
+			this.score = score;
+			this.voteRatio = voteRatio;
+			this.id = id;
 		}
 
 	}

--- a/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import com.example.baseballprediction.domain.game.dto.GameResponse.GameDtoDaily;
 import com.example.baseballprediction.domain.game.entity.Game;
 import com.example.baseballprediction.domain.game.repository.GameRepository;
+import com.example.baseballprediction.domain.gamevote.dto.GameVoteRatioDTO;
+import com.example.baseballprediction.domain.gamevote.repository.GameVoteRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 public class GameService {
 
 	private final GameRepository gameRepository;
+	private final GameVoteRepository gameVoteRepository;
 	
 
 	public List<GameDtoDaily> findDailyGame(){
@@ -28,7 +31,9 @@ public class GameService {
 			String gameFormatDate = game.getStartedAt().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 			
 			  if(gameFormatDate.equals(formatDate)) {
-				  GameDtoDaily dailygame = new GameDtoDaily(game,game.getAwayTeam() ,game.getHomeTeam());
+				  GameVoteRatioDTO gameVoteRatioDTO = gameVoteRepository.findVoteRatio(game.getHomeTeam().getId(), game.getAwayTeam().getId(), games.get(0).getId()).orElseThrow();
+				  
+				  GameDtoDaily dailygame = new GameDtoDaily(game,game.getHomeTeam(),game.getAwayTeam(),gameVoteRatioDTO);
 					
 				  gameDTOList.add(dailygame);
 			  

--- a/src/main/java/com/example/baseballprediction/domain/gamevote/dto/GameVoteRatioDTO.java
+++ b/src/main/java/com/example/baseballprediction/domain/gamevote/dto/GameVoteRatioDTO.java
@@ -1,0 +1,7 @@
+package com.example.baseballprediction.domain.gamevote.dto;
+
+public interface GameVoteRatioDTO {
+	 int getHomeTeamVoteRatio();
+	 int getAwayTeamVoteRatio();
+}
+

--- a/src/main/java/com/example/baseballprediction/domain/gamevote/repository/GameVoteRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/gamevote/repository/GameVoteRepository.java
@@ -1,11 +1,25 @@
 package com.example.baseballprediction.domain.gamevote.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.baseballprediction.domain.gamevote.dto.GameVoteRatioDTO;
 import com.example.baseballprediction.domain.gamevote.entity.GameVote;
 
 public interface GameVoteRepository extends JpaRepository<GameVote, Long> {
 	
 	GameVote findByMemberIdAndGameId(Long memberId, Long gameId);
+	
+	@Query(
+			value =
+			"SELECT "
+			+ "concat(round((( (select count(team_id) from game_vote gv2 where gv2.team_id =:homeTeamid and game_id =:gameId )  / count(game_id)) * 100 ))) as homeTeamVoteRatio ,"
+			+ " concat(round((( (select count(team_id) from game_vote gv2 where gv2.team_id =:awayTeamid and game_id =:gameId )  / count(game_id)) * 100 ))) as awayTeamVoteRatio "
+			+ " from game_vote gv "
+			+ " where game_id =:gameId", nativeQuery = true)
+	Optional<GameVoteRatioDTO> findVoteRatio(@Param("homeTeamid") int homeTeamid, @Param("awayTeamid") int awayTeamid, @Param("gameId") Long gameId);
 	
 }


### PR DESCRIPTION
### Feat: 오늘의 승부예측 퍼센트 & 경기 스코어 api

-**GameVoteRatioDTO** -> gameRepository nativeQuery사용 하기 위한 인터페이스 
-**GameResponse** -> 오늘의 승부예측 퍼센트 & 스코어 & teamId값을 가져오기 위해 메소드안 값 추가
-**GameService** -> VoteRatio를 가져오는 쿼리 실행후 GameDtoDaily에 알맞게 값 셋팅
-**GameRepository**-> 오늘의 승부예측 퍼센트율 구하는 쿼리설정

Ref: #86 