### PR TITLE
오늘의 승부예측, 월간 승리요정 대댓글 작성 API 구현, 오늘의 승부예측 대댓글 조회 API 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/game/controller/GameController.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/controller/GameController.java
@@ -23,6 +23,7 @@ import com.example.baseballprediction.domain.game.service.GameService;
 import com.example.baseballprediction.domain.gamevote.dto.GameVoteRequest.GameVoteRequestDTO;
 import com.example.baseballprediction.domain.gamevote.service.GameVoteService;
 import com.example.baseballprediction.domain.reply.dto.ReplyRequest;
+import com.example.baseballprediction.domain.reply.dto.ReplyResponse;
 import com.example.baseballprediction.domain.reply.service.ReplyService;
 import com.example.baseballprediction.domain.replylike.service.ReplyLikeService;
 import com.example.baseballprediction.global.constant.ReplyType;
@@ -112,6 +113,23 @@ public class GameController {
 		gameVoteService.removeGameVote(gameId, memberDetails.getUsername());
 
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	@GetMapping("/daily-replies/{replyId}/sub")
+	public ResponseEntity<ApiResponse<List<ReplyResponse.ReplyDTO>>> replySubList(@PathVariable Long replyId) {
+		List<ReplyResponse.ReplyDTO> replies = replyService.findSubReplies(replyId);
+
+		ApiResponse<List<ReplyResponse.ReplyDTO>> response = ApiResponse.success(replies);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/daily-replies/{replyId}/sub")
+	public ResponseEntity<ApiResponse> replySubAdd(@PathVariable Long replyId,
+		@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody ReplyRequest.ReplyDTO replyDTO) {
+		replyService.addSubReply(replyId, ReplyType.GAME, memberDetails.getUsername(), replyDTO.getContent());
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess());
 	}
 
 }

--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/controller/MonthlyFairyController.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/controller/MonthlyFairyController.java
@@ -95,4 +95,13 @@ public class MonthlyFairyController {
 
 		return ResponseEntity.ok(response);
 	}
+
+	@PostMapping("/replies/{replyId}/sub")
+	public ResponseEntity<ApiResponse> replySubAdd(@PathVariable Long replyId,
+		@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody
+	@Valid ReplyRequest.ReplyDTO replyDTO) {
+		replyService.addSubReply(replyId, ReplyType.FAIRY, memberDetails.getUsername(), replyDTO.getContent());
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess());
+	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/reply/entity/Reply.java
+++ b/src/main/java/com/example/baseballprediction/domain/reply/entity/Reply.java
@@ -44,9 +44,10 @@ public class Reply extends BaseEntity {
 	private ReplyType type;
 
 	@Builder
-	public Reply(Member member, String content, ReplyType type) {
+	public Reply(Member member, String content, ReplyType type, Reply parentReply) {
 		this.member = member;
 		this.content = content;
 		this.type = type;
+		this.parentReply = parentReply;
 	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/reply/service/ReplyService.java
+++ b/src/main/java/com/example/baseballprediction/domain/reply/service/ReplyService.java
@@ -53,6 +53,23 @@ public class ReplyService {
 		replyRepository.save(reply);
 	}
 
+	public void addSubReply(Long replyId, ReplyType replyType, String username, String content) {
+		Reply parentReply = replyRepository.findById(replyId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.REPLY_NOT_FOUND));
+
+		Member member = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+		Reply reply = Reply.builder()
+			.member(member)
+			.content(content)
+			.type(replyType)
+			.parentReply(parentReply)
+			.build();
+
+		replyRepository.save(reply);
+	}
+
 	public void deleteReply(Long replyId, String username) {
 		Member member = memberRepository.findByUsername(username)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));


### PR DESCRIPTION
closed #87 

1. 오늘의 승부예측
  - /games/daily-replies/{replyId}/sub
  - 대댓글 조회 : GET 요청
  - 대댓글 작성 : POST 요청

2. 월간 승리요정 대댓글 작성 API 기능 구현
  - /statistics/replies/{replyId}/sub