### PR TITLE
월간 승리요정 집계 기능 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/BaseballPredictionApplication.java
+++ b/src/main/java/com/example/baseballprediction/BaseballPredictionApplication.java
@@ -3,13 +3,15 @@ package com.example.baseballprediction;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class BaseballPredictionApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(BaseballPredictionApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(BaseballPredictionApplication.class, args);
+	}
 
 }

--- a/src/main/java/com/example/baseballprediction/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/repository/GameRepository.java
@@ -1,7 +1,12 @@
 package com.example.baseballprediction.domain.game.repository;
 
-import com.example.baseballprediction.domain.game.entity.Game;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.example.baseballprediction.domain.game.entity.Game;
+
 public interface GameRepository extends JpaRepository<Game, Long> {
+	List<Game> findAllByStartedAtBetween(LocalDateTime startedAtStart, LocalDateTime startedAtEnd);
 }

--- a/src/main/java/com/example/baseballprediction/domain/member/entity/Member.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/entity/Member.java
@@ -74,6 +74,12 @@ public class Member extends BaseEntity {
 	@Transient
 	private boolean isNewMember;
 
+	@Transient
+	private int voteScore;
+
+	@Transient
+	private int voteRatio;
+
 	@Builder
 	public Member(Long id, String username, String password, String nickname, SocialType socialType,
 		boolean isNewMember) {
@@ -102,5 +108,13 @@ public class Member extends BaseEntity {
 
 	public void setIsNewMember(boolean isNewMember) {
 		this.isNewMember = isNewMember;
+	}
+
+	public void sumVoteScore(int voteScore) {
+		this.voteScore += voteScore;
+	}
+
+	public void setVoteRatio(int voteRatio) {
+		this.voteRatio = voteRatio;
 	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/monthlyfairy/entity/MonthlyFairy.java
+++ b/src/main/java/com/example/baseballprediction/domain/monthlyfairy/entity/MonthlyFairy.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -43,4 +44,13 @@ public class MonthlyFairy extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	@Builder
+	public MonthlyFairy(int month, FairyType type, int rank, int voteRatio, Member member) {
+		this.month = month;
+		this.type = type;
+		this.rank = rank;
+		this.voteRatio = voteRatio;
+		this.member = member;
+	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/team/entity/Team.java
+++ b/src/main/java/com/example/baseballprediction/domain/team/entity/Team.java
@@ -1,5 +1,7 @@
 package com.example.baseballprediction.domain.team.entity;
 
+import java.util.Objects;
+
 import com.example.baseballprediction.domain.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -29,4 +31,20 @@ public class Team extends BaseEntity {
 	private String shortName;
 	@Column(length = 16)
 	private String color;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof Team)) {
+			return false;
+		}
+		Team team = (Team)o;
+		return id == team.getId();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
 }

--- a/src/main/java/com/example/baseballprediction/global/schedule/service/MonthlyFairyScheduleService.java
+++ b/src/main/java/com/example/baseballprediction/global/schedule/service/MonthlyFairyScheduleService.java
@@ -1,0 +1,155 @@
+package com.example.baseballprediction.global.schedule.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.baseballprediction.domain.game.entity.Game;
+import com.example.baseballprediction.domain.game.repository.GameRepository;
+import com.example.baseballprediction.domain.gamevote.entity.GameVote;
+import com.example.baseballprediction.domain.gamevote.repository.GameVoteRepository;
+import com.example.baseballprediction.domain.member.entity.Member;
+import com.example.baseballprediction.domain.member.repository.MemberRepository;
+import com.example.baseballprediction.domain.monthlyfairy.entity.MonthlyFairy;
+import com.example.baseballprediction.domain.monthlyfairy.repository.MonthlyFairyRepository;
+import com.example.baseballprediction.global.constant.FairyType;
+import com.example.baseballprediction.global.util.CustomDateUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyFairyScheduleService {
+	private final GameVoteRepository gameVoteRepository;
+	private final GameRepository gameRepository;
+	private final MemberRepository memberRepository;
+
+	private final MonthlyFairyRepository monthlyFairyRepository;
+
+	@Scheduled(cron = "0 0 2 1 * *", zone = "Asia/Seoul")
+	public void execute() {
+		aggregateMonthlyFairy(LocalDateTime.now());
+	}
+
+	@Transactional(readOnly = true)
+	public void aggregateMonthlyFairy(LocalDateTime aggregateDateTime) {
+		LocalDateTime aggregateDateStart = LocalDateTime.of(aggregateDateTime.getYear(), aggregateDateTime.getMonth(),
+			1, 0, 0);
+
+		LocalDate aggregateDate = CustomDateUtil.parseLocalDate(aggregateDateTime);
+		LocalDateTime aggregateDateEnd = LocalDateTime.of(aggregateDate.getYear(), aggregateDate.getMonth(),
+			aggregateDate.lengthOfMonth(), 23, 59);
+
+		List<Game> games = findGamesByaggregateDate(aggregateDateStart, aggregateDateEnd);
+
+		if (games.size() == 0)
+			return;
+
+		List<Member> members = memberRepository.findAll();
+
+		if (members.size() == 0)
+			return;
+
+		members = aggregateVoteMembers(members, games);
+
+		Map<FairyType, List<Member>> allFairies = findWinLoseFairies(members);
+
+		addMonthlyFairies(allFairies);
+	}
+
+	@Transactional(readOnly = true)
+	private List<Game> findGamesByaggregateDate(LocalDateTime aggregateDateStart, LocalDateTime aggregateDateEnd) {
+		List<Game> games = gameRepository.findAllByStartedAtBetween(aggregateDateStart, aggregateDateEnd);
+
+		return games;
+	}
+
+	@Transactional(readOnly = true)
+	private List<Member> aggregateVoteMembers(List<Member> members, List<Game> games) {
+		int gameCount = games.size();
+
+		for (Member member : members) {
+			int winVoteCount = 0;
+
+			for (Game game : games) {
+				GameVote gameVote = gameVoteRepository.findByMemberIdAndGameId(member.getId(), game.getId());
+				if (gameVote == null) {
+					member.sumVoteScore(-1);
+					continue;
+				}
+
+				int winTeam = game.getWinTeam().getId();
+				int voteTeam = gameVote.getTeam().getId();
+
+				if (winTeam == voteTeam) {
+					member.sumVoteScore(1);
+					winVoteCount++;
+				} else {
+					member.sumVoteScore(-1);
+				}
+			}
+
+			if (winVoteCount > 0) {
+				double var = (double)winVoteCount / (double)gameCount;
+				member.setVoteRatio((int)Math.round(var * 100));
+			}
+		}
+
+		members = members.stream().sorted(Comparator.comparing(Member::getVoteScore)).toList();
+
+		return members;
+	}
+
+	private Map<FairyType, List<Member>> findWinLoseFairies(List<Member> members) {
+		List<Member> winFairies = new ArrayList<>();
+		List<Member> loseFairies = new ArrayList<>();
+
+		for (int i = 0; i < 5; i++) {
+			loseFairies.add(members.get(i));
+			winFairies.add(members.get(members.size() - i - 1));
+		}
+
+		Map<FairyType, List<Member>> response = new HashMap<>();
+
+		response.put(FairyType.WIN, winFairies);
+		response.put(FairyType.LOSE, loseFairies);
+
+		return response;
+	}
+
+	private void addMonthlyFairies(Map<FairyType, List<Member>> fairies) {
+		Iterator<FairyType> keys = fairies.keySet().iterator();
+		while (keys.hasNext()) {
+			FairyType key = keys.next();
+			List<Member> members = fairies.get(key);
+
+			for (int i = 0; i < members.size(); i++) {
+				addMonthlyFairyByType(LocalDateTime.now(), key, i + 1, members.get(i));
+			}
+		}
+	}
+
+	@Transactional
+	private void addMonthlyFairyByType(LocalDateTime aggregateDate, FairyType fairyType, int rank, Member member) {
+		int month = Integer.parseInt(CustomDateUtil.dateToYearMonth(aggregateDate));
+
+		MonthlyFairy monthlyFairy = MonthlyFairy.builder()
+			.month(month)
+			.member(member)
+			.rank(rank)
+			.voteRatio(member.getVoteRatio())
+			.type(fairyType)
+			.build();
+
+		monthlyFairyRepository.save(monthlyFairy);
+	}
+}

--- a/src/main/java/com/example/baseballprediction/global/util/CustomDateUtil.java
+++ b/src/main/java/com/example/baseballprediction/global/util/CustomDateUtil.java
@@ -17,4 +17,12 @@ public class CustomDateUtil {
 	public static String dateToString(LocalDate date) {
 		return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 	}
+
+	public static LocalDate parseLocalDate(LocalDateTime dateTime) {
+		return dateTime.toLocalDate();
+	}
+
+	public static String dateToYearMonth(LocalDateTime dateTime) {
+		return dateTime.format(DateTimeFormatter.ofPattern("yyyyMM")).toString();
+	}
 }


### PR DESCRIPTION
closed #23 

- 매월 1일 02시에 스케쥴러 동작
- 당월 경기들 기준으로 투표 점수 산정 (승리팀 적중 : +1점 / 미적중, 무투표 -1점)
- 적중률 = 승리팀 적중 수 / 당월 경기 수 * 100
- 산정된 점수로 승리요정 5명, 패배요정 5명 저장