### PR TITLE
지난 승부예측 조회 API 기능구현, 자체 로그인 토큰 헤더에 안담기는 문제 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/game/controller/GameController.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/controller/GameController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.baseballprediction.domain.game.dto.GameResponse;
 import com.example.baseballprediction.domain.game.dto.GameResponse.GameDtoDaily;
 import com.example.baseballprediction.domain.game.service.GameService;
 import com.example.baseballprediction.domain.gamevote.dto.GameVoteRequest.GameVoteRequestDTO;
@@ -130,6 +131,18 @@ public class GameController {
 		replyService.addSubReply(replyId, ReplyType.GAME, memberDetails.getUsername(), replyDTO.getContent());
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess());
+	}
+
+	@GetMapping("/past")
+	public ResponseEntity<ApiResponse<List<GameResponse.PastGameDTO>>> gameWeekList(@RequestParam String startDate,
+		@RequestParam String endDate,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		List<GameResponse.PastGameDTO> gameResults = gameService.findGameResult(memberDetails.getUsername(), startDate,
+			endDate);
+
+		ApiResponse<List<GameResponse.PastGameDTO>> response = ApiResponse.success(gameResults);
+
+		return ResponseEntity.ok(response);
 	}
 
 }

--- a/src/main/java/com/example/baseballprediction/domain/game/dto/GameResponse.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/dto/GameResponse.java
@@ -32,10 +32,12 @@ public class GameResponse {
 
 		private String status;
 
-		public GameDtoDaily(Game game, Team homeTeam, Team awayTeam,GameVoteRatioDTO gameVoteRatioDTO) {
+		public GameDtoDaily(Game game, Team homeTeam, Team awayTeam, GameVoteRatioDTO gameVoteRatioDTO) {
 			this.gameId = game.getId();
-			this.homeTeam = new TeamDailyDTO(homeTeam, game.getHomeTeamScore(),gameVoteRatioDTO.getHomeTeamVoteRatio(),homeTeam.getId());
-			this.awayTeam = new TeamDailyDTO(awayTeam, game.getAwayTeamScore(),gameVoteRatioDTO.getAwayTeamVoteRatio(),awayTeam.getId());
+			this.homeTeam = new TeamDailyDTO(homeTeam, game.getHomeTeamScore(), gameVoteRatioDTO.getHomeTeamVoteRatio(),
+				homeTeam.getId());
+			this.awayTeam = new TeamDailyDTO(awayTeam, game.getAwayTeamScore(), gameVoteRatioDTO.getAwayTeamVoteRatio(),
+				awayTeam.getId());
 			this.gameTime = game.getStartedAt();
 			this.status = game.getStatus().toString();
 		}
@@ -50,9 +52,8 @@ public class GameResponse {
 		private int score;
 		private int voteRatio;
 		private int id;
-		
 
-		public TeamDailyDTO(Team team,int score, int voteRatio, int id) {
+		public TeamDailyDTO(Team team, int score, int voteRatio, int id) {
 			this.teamName = team.getName();
 			this.teamShortName = team.getShortName();
 			this.score = score;
@@ -60,6 +61,34 @@ public class GameResponse {
 			this.id = id;
 		}
 
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class PastGameDTO {
+		private Long gameId;
+		private PastGameTeamDTO homeTeam;
+		private PastGameTeamDTO awayTeam;
+		private String gameDate;
+		private Integer voteTeamId;
+
+		public PastGameDTO(GameVoteProjection gameVoteProjection, GameVoteRatioDTO gameVoteRatioDTO) {
+			this.gameId = gameVoteProjection.getGameId();
+			this.homeTeam = new PastGameTeamDTO(gameVoteProjection.getHomeTeamId(),
+				gameVoteProjection.getHomeTeamName(), gameVoteRatioDTO.getHomeTeamVoteRatio());
+			this.awayTeam = new PastGameTeamDTO(gameVoteProjection.getAwayTeamId(),
+				gameVoteProjection.getAwayTeamName(), gameVoteRatioDTO.getAwayTeamVoteRatio());
+			this.gameDate = gameVoteProjection.getStartDate();
+			this.voteTeamId = gameVoteProjection.getVoteTeamId();
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class PastGameTeamDTO {
+		private int id;
+		private String teamName;
+		private int voteRatio;
 	}
 
 }

--- a/src/main/java/com/example/baseballprediction/domain/game/dto/GameVoteProjection.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/dto/GameVoteProjection.java
@@ -1,0 +1,17 @@
+package com.example.baseballprediction.domain.game.dto;
+
+public interface GameVoteProjection {
+	Long getGameId();
+
+	String getStartDate();
+
+	Integer getHomeTeamId();
+
+	String getHomeTeamName();
+
+	Integer getAwayTeamId();
+
+	String getAwayTeamName();
+
+	Integer getVoteTeamId();
+}

--- a/src/main/java/com/example/baseballprediction/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/repository/GameRepository.java
@@ -4,9 +4,31 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import com.example.baseballprediction.domain.game.dto.GameVoteProjection;
 import com.example.baseballprediction.domain.game.entity.Game;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 	List<Game> findAllByStartedAtBetween(LocalDateTime startedAtStart, LocalDateTime startedAtEnd);
+
+	// @Query(value =
+	// 	"SELECT g.game_id, date_format(g.startedAt, '%Y.%m.%d') start_date, g.home_team_id, t.name home_team_name,"
+	// 		+ " g.away_team_id, t2.name away_team_name, v.team_id"
+	// 		+ "  FROM game g LEFT JOIN (SELECT * FROM game_vote WHERE v.member_id = :memberId) v on v.game_id = g.game_id"
+	// 		+ "  INNER JOIN team t ON g.home_team_id = t.team_id"
+	// 		+ "  INNER JOIN team t2 ON g.away_team_id = t2.team_id"
+	// 		+ " WHERE g.started_at >= :startedAtStart and g.started_at <= :startedAtEnd", nativeQuery = true)
+	// List<GameVoteProjection> findPastGameByStartedAtBetween(Long memberId, LocalDateTime staredAtStart,
+	// 	LocalDateTime startedAtEnd);
+
+	@Query(value =
+		"SELECT g.game_id gameId, date_format(g.started_at, '%Y.%m.%d') startDate, g.home_team_id homeTeamId, t.name homeTeamName,"
+			+ " g.away_team_id awayTeamId, t2.name awayTeamName, v.team_id voteTeamId"
+			+ "  FROM game g LEFT JOIN (SELECT * FROM game_vote WHERE member_id = :memberId) v on v.game_id = g.game_id"
+			+ "  INNER JOIN team t ON g.home_team_id = t.team_id"
+			+ "  INNER JOIN team t2 ON g.away_team_id = t2.team_id"
+			+ " WHERE g.started_at >= :startedAtStart and g.started_at <= :startedAtEnd", nativeQuery = true)
+	List<GameVoteProjection> findPastGameByStartedAtBetween(Long memberId, LocalDateTime startedAtStart,
+		LocalDateTime startedAtEnd);
 }

--- a/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
@@ -1,15 +1,25 @@
 package com.example.baseballprediction.domain.game.service;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.springframework.stereotype.Service;
+
+import com.example.baseballprediction.domain.game.dto.GameResponse;
 import com.example.baseballprediction.domain.game.dto.GameResponse.GameDtoDaily;
+import com.example.baseballprediction.domain.game.dto.GameVoteProjection;
 import com.example.baseballprediction.domain.game.entity.Game;
 import com.example.baseballprediction.domain.game.repository.GameRepository;
 import com.example.baseballprediction.domain.gamevote.dto.GameVoteRatioDTO;
 import com.example.baseballprediction.domain.gamevote.repository.GameVoteRepository;
+import com.example.baseballprediction.domain.member.entity.Member;
+import com.example.baseballprediction.domain.member.repository.MemberRepository;
+import com.example.baseballprediction.global.constant.ErrorCode;
+import com.example.baseballprediction.global.error.exception.NotFoundException;
+import com.example.baseballprediction.global.util.CustomDateUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,32 +29,56 @@ public class GameService {
 
 	private final GameRepository gameRepository;
 	private final GameVoteRepository gameVoteRepository;
-	
+	private final MemberRepository memberRepository;
 
-	public List<GameDtoDaily> findDailyGame(){
+	public List<GameDtoDaily> findDailyGame() {
 		List<Game> games = gameRepository.findAll();
-		
+
 		List<GameDtoDaily> gameDTOList = new ArrayList<>();
-		
-		for(Game game : games) {
+
+		for (Game game : games) {
 			String formatDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 			String gameFormatDate = game.getStartedAt().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-			
-			  if(gameFormatDate.equals(formatDate)) {
-				  GameVoteRatioDTO gameVoteRatioDTO = gameVoteRepository.findVoteRatio(game.getHomeTeam().getId(), game.getAwayTeam().getId(), game.getId()).orElseThrow();
-				  
-				  GameDtoDaily dailygame = new GameDtoDaily(game,game.getHomeTeam(),game.getAwayTeam(),gameVoteRatioDTO);
-					
-				  gameDTOList.add(dailygame);
-			  
-			  }
-			
+
+			if (gameFormatDate.equals(formatDate)) {
+				GameVoteRatioDTO gameVoteRatioDTO = gameVoteRepository.findVoteRatio(game.getHomeTeam().getId(),
+					game.getAwayTeam().getId(), game.getId()).orElseThrow();
+
+				GameDtoDaily dailygame = new GameDtoDaily(game, game.getHomeTeam(), game.getAwayTeam(),
+					gameVoteRatioDTO);
+
+				gameDTOList.add(dailygame);
+
+			}
+
 		}
-		
+
 		return gameDTOList;
-		
-		
+
 	}
-	
-	
+
+	public List<GameResponse.PastGameDTO> findGameResult(String username, String startDate, String endDate) {
+		Member member = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+		LocalDateTime startDateTime = LocalDateTime.of(CustomDateUtil.stringToDate(startDate), LocalTime.of(0, 0));
+		LocalDateTime endDateTime = LocalDateTime.of(CustomDateUtil.stringToDate(endDate), LocalTime.of(23, 59));
+
+		List<GameVoteProjection> gameVoteProjections = gameRepository.findPastGameByStartedAtBetween(member.getId(),
+			startDateTime, endDateTime);
+
+		List<GameResponse.PastGameDTO> gameResults = new ArrayList<>();
+
+		for (GameVoteProjection gameVoteProjection : gameVoteProjections) {
+			Integer homeTeamId = gameVoteProjection.getHomeTeamId();
+			Integer awayTeamId = gameVoteProjection.getAwayTeamId();
+			GameVoteRatioDTO gameVoteRatioDTO = gameVoteRepository.findVoteRatio(gameVoteProjection.getHomeTeamId(),
+				gameVoteProjection.getAwayTeamId(), gameVoteProjection.getGameId()).orElseThrow();
+
+			gameResults.add(new GameResponse.PastGameDTO(gameVoteProjection, gameVoteRatioDTO));
+		}
+
+		return gameResults;
+	}
+
 }

--- a/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
@@ -25,6 +25,7 @@ import com.example.baseballprediction.domain.member.dto.MemberResponse;
 import com.example.baseballprediction.domain.member.dto.ProfileProjection;
 import com.example.baseballprediction.domain.member.service.MemberService;
 import com.example.baseballprediction.global.security.MemberDetails;
+import com.example.baseballprediction.global.security.jwt.JwtTokenProvider;
 import com.example.baseballprediction.global.util.ApiResponse;
 
 import jakarta.validation.Valid;
@@ -41,7 +42,7 @@ public class MemberController {
 
 		ApiResponse<Map<String, Object>> apiResponse = ApiResponse.success(response);
 
-		return ResponseEntity.ok(apiResponse);
+		return ResponseEntity.ok().header(JwtTokenProvider.HEADER, (String)response.get("token")).body(apiResponse);
 	}
 
 	@PutMapping("/profile/team")

--- a/src/main/java/com/example/baseballprediction/global/util/CustomDateUtil.java
+++ b/src/main/java/com/example/baseballprediction/global/util/CustomDateUtil.java
@@ -25,4 +25,8 @@ public class CustomDateUtil {
 	public static String dateToYearMonth(LocalDateTime dateTime) {
 		return dateTime.format(DateTimeFormatter.ofPattern("yyyyMM")).toString();
 	}
+
+	public static LocalDate stringToDate(String date) {
+		return LocalDate.parse(date);
+	}
 }


### PR DESCRIPTION
closed #103 

1. 지난 승부예측 조회 API 기능 구현
  - 시작일, 종료일 QueryString으로 받아서 해당 기간의 경기를 조회하도록 구현
  
2. 자체 로그인 시, 토큰 헤더에 안담기는 문제 수정
  - 응답 포맷 적용하면서 바디에 담도록 잘못 수정했었음.. 헤더에도 담도록 다시 수정함