### PR TITLE
댓글 조회 QueryDSL 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ dependencies {
     //S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('bootBuildImage') {
@@ -82,4 +88,8 @@ tasks {
     processResources {
         duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.INCLUDE
     }
+}
+
+clean {
+    delete file('src/main/generated')
 }

--- a/src/main/java/com/example/baseballprediction/domain/reply/repository/ReplyRepositoryCustom.java
+++ b/src/main/java/com/example/baseballprediction/domain/reply/repository/ReplyRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.baseballprediction.domain.reply.repository;
+
+import java.util.List;
+
+import com.example.baseballprediction.domain.reply.entity.Reply;
+
+public interface ReplyRepositoryCustom {
+	List<Reply> findAllReplies();
+}

--- a/src/main/java/com/example/baseballprediction/domain/reply/repository/ReplyRepositoryCustomImpl.java
+++ b/src/main/java/com/example/baseballprediction/domain/reply/repository/ReplyRepositoryCustomImpl.java
@@ -1,0 +1,74 @@
+package com.example.baseballprediction.domain.reply.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.example.baseballprediction.domain.member.entity.QMember;
+import com.example.baseballprediction.domain.reply.dto.ReplyLikeProjection;
+import com.example.baseballprediction.domain.reply.entity.QReply;
+import com.example.baseballprediction.domain.replylike.entity.QReplyLike;
+import com.example.baseballprediction.domain.team.entity.QTeam;
+import com.example.baseballprediction.global.constant.ReplyType;
+import com.example.baseballprediction.global.util.CustomDateUtil;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyRepositoryCustomImpl {
+	private final JPAQueryFactory queryFactory;
+
+	public Page<ReplyLikeProjection> findAllRepliesByType(ReplyType replyType, Pageable pageable) {
+		QReply reply = QReply.reply;
+		QReplyLike replyLike = QReplyLike.replyLike;
+		QMember member = QMember.member;
+		QTeam team = QTeam.team;
+
+		StringExpression dateCondition = Expressions.stringTemplate("FUNCTION('DATE_FORMAT', {0}, '%Y-%m-%d')",
+			reply.createdAt);
+
+		BooleanExpression whereCondition;
+		if (replyType == ReplyType.FAIRY) {
+			LocalDate aggregateDateStart = LocalDate.of(LocalDate.now().getYear(), LocalDate.now().getMonth(), 1);
+			LocalDate aggregateDateEnd = LocalDate.of(aggregateDateStart.getYear(),
+				aggregateDateStart.getMonthValue(),
+				aggregateDateStart.lengthOfMonth());
+
+			whereCondition = dateCondition.between(CustomDateUtil.dateToString(aggregateDateStart),
+				CustomDateUtil.dateToString(aggregateDateEnd));
+		} else {
+			whereCondition = dateCondition.eq(CustomDateUtil.dateToString(LocalDate.now()));
+		}
+
+		JPAQuery<ReplyLikeProjection> query = queryFactory.select(
+				Projections.constructor(ReplyLikeProjection.class, reply.id, replyLike.id.count().as("count"),
+					reply.createdAt,
+					reply.content, member.profileImageUrl, member.nickname, team.name))
+			.from(reply)
+			.leftJoin(member).on(reply.member.id.eq(member.id))
+			.leftJoin(team).on(reply.member.team.id.eq(team.id))
+			.leftJoin(replyLike).on(replyLike.reply.id.eq(reply.id))
+			.where(reply.type.eq(replyType), whereCondition, reply.parentReply.isNull())
+			.groupBy(reply.id)
+			.orderBy(reply.createdAt.desc());
+
+		List<ReplyLikeProjection> projections = query.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long count = query.fetchCount();
+
+		return new PageImpl<>(projections, pageable, count);
+	}
+}

--- a/src/main/java/com/example/baseballprediction/domain/reply/service/ReplyService.java
+++ b/src/main/java/com/example/baseballprediction/domain/reply/service/ReplyService.java
@@ -15,6 +15,7 @@ import com.example.baseballprediction.domain.member.repository.MemberRepository;
 import com.example.baseballprediction.domain.reply.dto.ReplyLikeProjection;
 import com.example.baseballprediction.domain.reply.entity.Reply;
 import com.example.baseballprediction.domain.reply.repository.ReplyRepository;
+import com.example.baseballprediction.domain.reply.repository.ReplyRepositoryCustomImpl;
 import com.example.baseballprediction.global.constant.ErrorCode;
 import com.example.baseballprediction.global.constant.ReplyType;
 import com.example.baseballprediction.global.error.exception.NotFoundException;
@@ -29,13 +30,14 @@ public class ReplyService {
 	private final ReplyRepository replyRepository;
 	private final MemberRepository memberRepository;
 
+	private final ReplyRepositoryCustomImpl replyRepositoryCustom;
+
 	@Transactional(readOnly = true)
 	public Page<ReplyDTO> findRepliesByType(ReplyType replyType, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
-
-		Page<ReplyLikeProjection> findGameAllReplyList = replyRepository.findReplyGame(replyType, pageable);
-
-		Page<ReplyDTO> replies = findGameAllReplyList.map(m -> new ReplyDTO(m));
+		
+		Page<ReplyLikeProjection> replyProjections = replyRepositoryCustom.findAllRepliesByType(replyType, pageable);
+		Page<ReplyDTO> replies = replyProjections.map(m -> new ReplyDTO(m));
 
 		return replies;
 	}

--- a/src/main/java/com/example/baseballprediction/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/baseballprediction/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.example.baseballprediction.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
closed #110 #111

- 오늘의 승부예측/월간 승리요정 댓글 조회 조건이 다르므로 쿼리 분기하지 않고 QueryDSL 사용하여 동적 쿼리 구현