### PR TITLE
Feat : 채팅방 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -58,6 +57,11 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+
+	//websocket
+	implementation 'org.webjars:sockjs-client:1.0.2'
+	implementation 'org.webjars:stomp-websocket:2.3.3'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/example/baseballprediction/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/controller/ChatController.java
@@ -1,0 +1,43 @@
+package com.example.baseballprediction.domain.chat.controller;
+
+
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.baseballprediction.domain.chat.dto.ChatMessage;
+import com.example.baseballprediction.global.constant.ChatType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+public class ChatController {
+	
+	private final SimpMessageSendingOperations messagingTemplate;
+	
+	@MessageMapping("/chat/message")
+	@SendTo("/sub/chat")
+	public void messageSave(ChatMessage message,@Header("nickname") String nickname,
+			@Header("profileImageUrl") String profileImageUrl,
+			@Header("teamName") String teamName) {
+		if(ChatType.ENTER.equals(message.getType())) {
+			if (nickname == null) {
+				nickname = "Unknown"; // header가 없을 경우 기본값 설정
+		    }
+			message.SendMessage(nickname + "님이 입장하셨습니다.");
+			message.SendProfile(nickname, profileImageUrl, teamName);
+			messagingTemplate.convertAndSend("/sub/chat/" + message.getGameId(), message);
+		}else if(ChatType.NOMAL.equals(message.getType())) {
+			message.SendProfile(nickname, profileImageUrl, teamName);
+			message.SendMessage(message.getMessage());
+			
+			messagingTemplate.convertAndSend("/sub/chat/" + message.getGameId(), message);
+		}else if(ChatType.BAWWLING.equals(message.getType())) {
+			message.SendProfile(nickname, profileImageUrl, teamName);
+			message.SendMessage(message.getMessage());
+			messagingTemplate.convertAndSend("/sub/chat/" + message.getGameId(), message);
+		}
+	}
+	
+}

--- a/src/main/java/com/example/baseballprediction/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,58 @@
+package com.example.baseballprediction.domain.chat.controller;
+
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import com.example.baseballprediction.domain.chat.dto.ChatProfileDTO;
+import com.example.baseballprediction.domain.chat.dto.ChatRoom;
+import com.example.baseballprediction.domain.chat.service.ChatService;
+import com.example.baseballprediction.global.security.MemberDetails;
+import com.example.baseballprediction.global.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@RequiredArgsConstructor
+@Log4j2
+@Controller
+@RequestMapping("chat")
+public class ChatRoomController {
+	private final ChatService chatService;
+	
+	//모든 채팅방 목록 반환
+	@GetMapping("/rooms")
+	public  ResponseEntity<ApiResponse<List<ChatRoom>>> roomList(){
+		List<ChatRoom> chatGameList =  chatService.findAllRoom();
+		ApiResponse<List<ChatRoom>> response = ApiResponse.success(chatGameList);
+		 return ResponseEntity.ok(response);
+	}
+	
+	
+	// 채팅방 생성
+	@PostMapping("/room")
+	public ResponseEntity<ApiResponse> createRoomAdd(@RequestParam Long gameId) {
+		 chatService.addChatRoom(gameId);
+		 return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess());
+	}
+	
+	
+	// 채팅방 입장 화면
+	@GetMapping("/room/enter/{gameId}")
+	public ResponseEntity<ApiResponse> roomDetail(Model model, 
+			@PathVariable String gameId,
+			@AuthenticationPrincipal MemberDetails memberDetails) {
+		Optional<ChatProfileDTO> chatProfileDTO =  chatService.findByUsername(memberDetails.getMember().getId());
+		ApiResponse<Optional<ChatProfileDTO>> response = ApiResponse.success(chatProfileDTO);
+		return ResponseEntity.ok(response);
+	}
+	
+}

--- a/src/main/java/com/example/baseballprediction/domain/chat/dto/ChatMessage.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/dto/ChatMessage.java
@@ -1,0 +1,33 @@
+package com.example.baseballprediction.domain.chat.dto;
+
+import com.example.baseballprediction.global.constant.ChatType;
+import lombok.Getter;
+
+@Getter
+public class ChatMessage {
+
+    private ChatType type;
+    private Long gameId;
+    private String message;
+    private String nickname;
+    private String profileImageUrl;
+    private String teamName;
+    
+    public void SendMessage(String message) {
+    	setMessage(message);
+    }
+    
+    private void setMessage(String message) {
+    	this.message = message;
+    }
+    
+    public void SendProfile(String nickname,String profileImageUrl,String teamName) {
+    	setProfile(nickname,profileImageUrl,teamName);
+    }
+    
+    private void setProfile(String nickname,String profileImageUrl,String teamName) {
+    	this.nickname = nickname;
+    	this.profileImageUrl = profileImageUrl;
+    	this.teamName = teamName;
+    }
+}

--- a/src/main/java/com/example/baseballprediction/domain/chat/dto/ChatProfileDTO.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/dto/ChatProfileDTO.java
@@ -1,0 +1,25 @@
+package com.example.baseballprediction.domain.chat.dto;
+
+
+import com.example.baseballprediction.domain.team.entity.Team;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatProfileDTO {
+	
+		private String nickname;
+		private String profileImageUrl;
+		private String TeamName;
+		
+		public ChatProfileDTO(String nickname,String profileImageUrl,Team team) {
+			this.nickname = nickname;
+			this.profileImageUrl = profileImageUrl;
+			this.TeamName = team.getName();
+		}
+		
+
+}

--- a/src/main/java/com/example/baseballprediction/domain/chat/dto/ChatRoom.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/dto/ChatRoom.java
@@ -1,0 +1,20 @@
+package com.example.baseballprediction.domain.chat.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoom {
+	
+	private Long gameId;
+	private String home;
+	private String away;
+	
+	public static ChatRoom create(Long gameId,String home,String away) {
+		ChatRoom chatRoom = new ChatRoom();
+		chatRoom.gameId =  gameId;
+		chatRoom.home = home;
+		chatRoom.away = away;
+		return chatRoom;
+	}
+	
+}

--- a/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
@@ -1,0 +1,50 @@
+package com.example.baseballprediction.domain.chat.service;
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.baseballprediction.domain.chat.dto.ChatProfileDTO;
+import com.example.baseballprediction.domain.chat.dto.ChatRoom;
+import com.example.baseballprediction.domain.game.entity.Game;
+import com.example.baseballprediction.domain.game.repository.GameRepository;
+import com.example.baseballprediction.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatService {
+	
+	private final GameRepository gameRepository;
+	private final MemberRepository memberRepository;
+	private Map<String, ChatRoom> chatRoomMap = new HashMap<>();
+	
+	public ChatRoom addChatRoom(Long gameId){
+		Optional<Game> games =  gameRepository.findById(gameId);
+		String home = games.get().getAwayTeam().getName();
+		String away = games.get().getHomeTeam().getName();
+		ChatRoom chatRoom = new ChatRoom().create (gameId,home, away);
+		chatRoomMap.put(chatRoom.getGameId().toString(), chatRoom);
+		return chatRoom;
+	}
+	
+	@Transactional(readOnly = true)
+	public List<ChatRoom> findAllRoom(){
+		List<ChatRoom> chatRooms = new ArrayList<>(chatRoomMap.values());
+		return chatRooms;
+	}
+	
+	@Transactional(readOnly = true)
+	public Optional<ChatProfileDTO> findByUsername(Long id) {
+		Optional<ChatProfileDTO> test= memberRepository.findByChatProfile(id);
+		return test;
+	}
+}

--- a/src/main/java/com/example/baseballprediction/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.example.baseballprediction.domain.chat.dto.ChatProfileDTO;
 import com.example.baseballprediction.domain.member.dto.FairyProjection;
 import com.example.baseballprediction.domain.member.dto.ProfileProjection;
 import com.example.baseballprediction.domain.member.entity.Member;
@@ -37,4 +38,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 		nativeQuery = true
 	)
 	List<FairyProjection> findFairyStatistics(Long memberId);
+	
+	@Query(
+			"SELECT new com.example.baseballprediction.domain.chat.dto.ChatProfileDTO("
+			+ " nickname, profileImageUrl, team.name)"
+			+ " FROM Member m"
+			+ " WHERE id = :memberId"
+			)
+	Optional<ChatProfileDTO> findByChatProfile(@Param("memberId")Long id);
 }

--- a/src/main/java/com/example/baseballprediction/global/config/WebSockConfig.java
+++ b/src/main/java/com/example/baseballprediction/global/config/WebSockConfig.java
@@ -1,0 +1,39 @@
+package com.example.baseballprediction.global.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import com.example.baseballprediction.global.error.handler.StompHandler;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSockConfig implements WebSocketMessageBrokerConfigurer {
+	
+	private final StompHandler stompHandler;
+	
+	@Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/chat").setAllowedOrigins("*")
+        .withSockJS(); // sock.js를 통하여 낮은 버전의 브라우저에서도 websocket이 동작할수 있게 설정
+		registry.addEndpoint("/chat").setAllowedOrigins("*"); // api 통신 시, withSockJS() 설정을 빼야됨
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        //메시지 브로커가 해당 api를 구독하고 있는 클라이언트에게 메시지를 전달
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub"); //메시지를 발행하기 위한 prefix
+    }
+    
+    // jwt 토큰 인증 핸들러
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
+    }
+}

--- a/src/main/java/com/example/baseballprediction/global/constant/ChatType.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/ChatType.java
@@ -1,0 +1,6 @@
+package com.example.baseballprediction.global.constant;
+
+public enum ChatType {
+	  NOMAL,BAWWLING,ENTER
+}
+

--- a/src/main/java/com/example/baseballprediction/global/error/handler/StompHandler.java
+++ b/src/main/java/com/example/baseballprediction/global/error/handler/StompHandler.java
@@ -1,0 +1,55 @@
+package com.example.baseballprediction.global.error.handler;
+
+
+import com.example.baseballprediction.domain.chat.dto.ChatMessage;
+import com.example.baseballprediction.domain.chat.dto.ChatRoom;
+import com.example.baseballprediction.global.security.MemberDetails;
+import com.example.baseballprediction.global.security.jwt.JwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+public class StompHandler implements ChannelInterceptor {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        System.out.println("message:" + message);
+        System.out.println("헤더 : " + message.getHeaders());
+        System.out.println("토큰" + accessor.getNativeHeader("Authorization"));
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+           // JwtTokenProvider.validateToken(Objects.requireNonNull(accessor.getFirstNativeHeader("Authorization")));
+        }
+        return message;
+    }
+}


### PR DESCRIPTION

1. ChatController 
- 채팅방 pub, sub 맵핑
- 채팅방 header값 nickname, profileImageUrl, teamName 추가
- request type값에 따라 로직 처리 
	type : ENTER -> 채팅방 입장 & nickname + "님이  입장하셨습니다."메세지 출력       
	type : NOMAL -> 일반 채팅  
	type : BAWWLING -> 외치기

2.ChatRoomController                                                              
- 채팅방 생성 api                                           
- 채팅방 목록 조회 api   
- 채팅방 header에 담을 api 
	
3.ChatMessage                                                            
- 채팅방 header값 nickname, profileImageUrl, teamName     
- 채팅방 request값 type, gameId, message 

4.ChatRoom  
- 채팅방 목록 조회시 gameId, home, away값 을 위한 dto 

5.ChatService 
- 채팅방 만들기, 채팅방 목록 조회 , 채팅방 header값 가져오는 service
 
6.MemberRepository 
- memberId로 header값 nickname, profileImageUrl, teamName 가져오는 쿼리 

7.WebSockConfig   
- endpoint설정 & sockjs사용 
- enableSimpleBroker("/sub"), setApplicationDestinationPrefixes("/pub") 설정
- header에 담긴 jwt토큰을 가져오는 interceptors설정 

8.ChatType 
- 입장하기 or 일반 채팅 or 외치기 구분 할 수 있는 NOMAL,BAWWLING,ENTER  enum 추가 

9.ChatProfileDTO  
- 채팅방 header에 담기는 nickname, profileImageUrl, teamName 관련 DTO  

10.StompHandler 
- jwt 토큰값 확인을 위한 handler 

11.build.gradle 
- sockjs, stomp 의존성 추가