### PR TITLE
닉네임 중복확인 API 요청 바디 -> 파라미터로 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
@@ -25,6 +25,8 @@ import com.example.baseballprediction.domain.member.dto.MemberRequest;
 import com.example.baseballprediction.domain.member.dto.MemberResponse;
 import com.example.baseballprediction.domain.member.dto.ProfileProjection;
 import com.example.baseballprediction.domain.member.service.MemberService;
+import com.example.baseballprediction.global.constant.ErrorCode;
+import com.example.baseballprediction.global.error.exception.BusinessException;
 import com.example.baseballprediction.global.security.MemberDetails;
 import com.example.baseballprediction.global.security.jwt.JwtTokenProvider;
 import com.example.baseballprediction.global.util.ApiResponse;
@@ -130,9 +132,16 @@ public class MemberController {
 	@GetMapping("/profile/nickname-check")
 	public ResponseEntity<ApiResponse<MemberResponse.NicknameDTO>> nicknameExistList(
 		@AuthenticationPrincipal MemberDetails memberDetails,
-		@Valid @RequestBody MemberRequest.NicknameDTO nicknameDTO) {
+		@RequestParam String nickname) {
+		if (nickname.length() > 20) {
+			throw new BusinessException(ErrorCode.MEMBER_NICKNAME_LENGTH);
+		}
+
+		if (nickname.isEmpty()) {
+			throw new BusinessException(ErrorCode.MEMBER_NICKNAME_NULL);
+		}
 		MemberResponse.NicknameDTO responseDTO = memberService.findExistNickname(memberDetails.getMember().getId(),
-			nicknameDTO.getNickname());
+			nickname);
 
 		ApiResponse<MemberResponse.NicknameDTO> response = ApiResponse.success(responseDTO);
 

--- a/src/main/java/com/example/baseballprediction/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/dto/MemberRequest.java
@@ -29,12 +29,4 @@ public class MemberRequest {
 		@Size(max = 100, message = "한마디는 100자 이하로 설정할 수 있습니다.")
 		private String comment;
 	}
-
-	@Getter
-	@NoArgsConstructor
-	public static class NicknameDTO {
-		@NotBlank(message = "닉네임을 입력해주세요.")
-		@Size(max = 20, message = "닉네임은 20자 이하로 설정할 수 있습니다.")
-		private String nickname;
-	}
 }

--- a/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
 	LOGIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그인에 실패했습니다. 다시 시도해주세요."),
 	MEMBER_NICKNAME_EXIST(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다."),
+	MEMBER_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 20자 이하로 입력해주세요."),
+	MEMBER_NICKNAME_NULL(HttpStatus.BAD_REQUEST, "닉네임은 공백일 수 없습니다."),
 	MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자 정보를 찾을 수 없습니다."),
 	TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "팀 정보를 찾을 수 없습니다."),
 	REPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "댓글 정보를 찾을 수 없습니다."),


### PR DESCRIPTION
closed #118 

- GET 메서드에 요청 바디는 RESTful하지 않으므로 Query String으로 닉네임 받도록 수정