### PR TITLE
경기 스코어 업데이트 스케줄러 기능 구현

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/game/entity/Game.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/entity/Game.java
@@ -1,57 +1,79 @@
 package com.example.baseballprediction.domain.game.entity;
 
-import com.example.baseballprediction.domain.team.entity.Team;
-import com.example.baseballprediction.global.constant.Status;
-import jakarta.persistence.*;
-import lombok.*;
+import java.time.LocalDateTime;
+
 import org.hibernate.annotations.ColumnDefault;
 
-import java.time.LocalDateTime;
+import com.example.baseballprediction.domain.team.entity.Team;
+import com.example.baseballprediction.global.constant.Status;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Game {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "game_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "game_id")
+	private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "home_team_id")
-    private Team homeTeam;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "home_team_id")
+	private Team homeTeam;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "away_team_id")
-    private Team awayTeam;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "away_team_id")
+	private Team awayTeam;
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 20)
-    private Status status;
+	@Enumerated(EnumType.STRING)
+	@Column(length = 20)
+	private Status status;
 
-    @Column(nullable = false)
-    private LocalDateTime startedAt;
+	@Column(nullable = false)
+	private LocalDateTime startedAt;
 
-    @Column(nullable = false)
-    @ColumnDefault("0")
-    private int homeTeamScore;
+	@Column(nullable = false)
+	@ColumnDefault("0")
+	private int homeTeamScore;
 
-    @Column(nullable = false)
-    @ColumnDefault("0")
-    private int awayTeamScore;
+	@Column(nullable = false)
+	@ColumnDefault("0")
+	private int awayTeamScore;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "win_team_id", unique = false)
-    private Team winTeam;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "win_team_id", unique = false)
+	private Team winTeam;
 
-    @Builder
-    public Game(Team homeTeam, Team awayTeam, Status status, LocalDateTime startedAt, int homeTeamScore, int awayTeamScore) {
-        this.homeTeam = homeTeam;
-        this.awayTeam = awayTeam;
-        this.status = status;
-        this.startedAt = startedAt;
-        this.homeTeamScore = homeTeamScore;
-        this.awayTeamScore = awayTeamScore;
-    }
+	@Builder
+	public Game(Team homeTeam, Team awayTeam, Status status, LocalDateTime startedAt, int homeTeamScore,
+		int awayTeamScore) {
+		this.homeTeam = homeTeam;
+		this.awayTeam = awayTeam;
+		this.status = status;
+		this.startedAt = startedAt;
+		this.homeTeamScore = homeTeamScore;
+		this.awayTeamScore = awayTeamScore;
+	}
+
+	public void updateByScrapeData(int homeTeamScore, int awayTeamScore, Status status) {
+		this.homeTeamScore = homeTeamScore;
+		this.awayTeamScore = awayTeamScore;
+		this.status = status;
+	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/repository/GameRepository.java
@@ -2,12 +2,14 @@ package com.example.baseballprediction.domain.game.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.example.baseballprediction.domain.game.dto.GameVoteProjection;
 import com.example.baseballprediction.domain.game.entity.Game;
+import com.example.baseballprediction.domain.team.entity.Team;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 	List<Game> findAllByStartedAtBetween(LocalDateTime startedAtStart, LocalDateTime startedAtEnd);
@@ -31,4 +33,6 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 			+ " WHERE g.started_at >= :startedAtStart and g.started_at <= :startedAtEnd", nativeQuery = true)
 	List<GameVoteProjection> findPastGameByStartedAtBetween(Long memberId, LocalDateTime startedAtStart,
 		LocalDateTime startedAtEnd);
+
+	Optional<Game> findByHomeTeamAndAwayTeamAndStartedAt(Team homeTeam, Team awayTeam, LocalDateTime startedAt);
 }

--- a/src/main/java/com/example/baseballprediction/global/constant/Status.java
+++ b/src/main/java/com/example/baseballprediction/global/constant/Status.java
@@ -1,5 +1,21 @@
 package com.example.baseballprediction.global.constant;
 
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Status {
-    READY, PROGRESS, END;
+	READY("cont"), PROGRESS("progress"), END("end"), CANCEL("cancel");
+
+	private final String name;
+
+	public static Status findByName(String name) {
+		return Arrays.stream(Status.values())
+			.filter(status -> status.name.equals(name))
+			.findFirst()
+			.orElseThrow();
+	}
 }

--- a/src/main/java/com/example/baseballprediction/global/schedule/service/GameScheduleService.java
+++ b/src/main/java/com/example/baseballprediction/global/schedule/service/GameScheduleService.java
@@ -1,0 +1,29 @@
+package com.example.baseballprediction.global.schedule.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.example.baseballprediction.global.scrape.service.ScrapeService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GameScheduleService {
+	private final ScrapeService scrapeService;
+
+	@Scheduled(cron = "0 0 2 1 3 * ", zone = "Asia/Seoul")
+	public void addGameSchedulesAll() {
+		scrapeService.addSchedules();
+	}
+
+	@Scheduled(cron = "0 0 18 * * 1-5", zone = "Asia/Seoul")
+	public void updateGameScoreByWeekDay() {
+		scrapeService.updateGameScore();
+	}
+
+	@Scheduled(cron = "0 0 13 * * 0,6", zone = "Asia/Seoul")
+	public void updateGameScoreByWeekend() {
+		scrapeService.updateGameScore();
+	}
+}

--- a/src/main/java/com/example/baseballprediction/global/scrape/controller/ScrapeController.java
+++ b/src/main/java/com/example/baseballprediction/global/scrape/controller/ScrapeController.java
@@ -1,22 +1,31 @@
 package com.example.baseballprediction.global.scrape.controller;
 
-import com.example.baseballprediction.global.scrape.service.ScrapeService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.baseballprediction.global.scrape.service.ScrapeService;
+
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/scrape")
 @RequiredArgsConstructor
 public class ScrapeController {
-    private final ScrapeService scrapeService;
+	private final ScrapeService scrapeService;
 
-    @PostMapping("/schedules")
-    public ResponseEntity<?> scrapeSchedules() {
-        scrapeService.addSchedules();
+	@PostMapping("/schedules")
+	public ResponseEntity<?> scrapeSchedules() {
+		scrapeService.addSchedules();
 
-        return ResponseEntity.ok().build();
-    }
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/scores")
+	public ResponseEntity<?> scrapeScores() {
+		scrapeService.updateGameScore();
+
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/example/baseballprediction/global/scrape/service/ScrapeService.java
+++ b/src/main/java/com/example/baseballprediction/global/scrape/service/ScrapeService.java
@@ -1,14 +1,7 @@
 package com.example.baseballprediction.global.scrape.service;
 
-import com.example.baseballprediction.domain.game.entity.Game;
-import com.example.baseballprediction.domain.game.repository.GameRepository;
-import com.example.baseballprediction.domain.team.entity.Team;
-import com.example.baseballprediction.domain.team.repository.TeamRepository;
-import com.example.baseballprediction.global.constant.Status;
-import com.example.baseballprediction.global.util.CustomDateUtil;
-import com.example.baseballprediction.global.util.WebDriverUtil;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -17,62 +10,144 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.Select;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import com.example.baseballprediction.domain.game.entity.Game;
+import com.example.baseballprediction.domain.game.repository.GameRepository;
+import com.example.baseballprediction.domain.team.entity.Team;
+import com.example.baseballprediction.domain.team.repository.TeamRepository;
+import com.example.baseballprediction.global.constant.Status;
+import com.example.baseballprediction.global.util.CustomDateUtil;
+import com.example.baseballprediction.global.util.WebDriverUtil;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ScrapeService {
-    private final TeamRepository teamRepository;
-    private final GameRepository gameRepository;
+	private final TeamRepository teamRepository;
+	private final GameRepository gameRepository;
 
-    public void addSchedules() {
-        WebDriver webDriver = WebDriverUtil.getChromeDriver();
-        try {
-            webDriver.get("https://www.koreabaseball.com/Schedule/Schedule.aspx");
-            Select yearSelector = new Select(webDriver.findElement(By.id("ddlYear")));
-            yearSelector.selectByIndex(0);
-            String year = yearSelector.getFirstSelectedOption().getAttribute("value");
+	private String currentDate;
 
-            Select monthSelector = new Select(webDriver.findElement(By.id("ddlMonth")));
-            monthSelector.selectByValue("04");
+	public void addSchedules() {
+		WebDriver webDriver = WebDriverUtil.getChromeDriver();
+		try {
+			webDriver.get("https://www.koreabaseball.com/Schedule/Schedule.aspx");
+			Select yearSelector = new Select(webDriver.findElement(By.id("ddlYear")));
+			yearSelector.selectByIndex(0);
+			String year = yearSelector.getFirstSelectedOption().getAttribute("value");
 
-            Document doc = Jsoup.parse(webDriver.getPageSource());
-            Elements baseballSchedules = doc.select("#tblScheduleList > tbody > tr");
+			Select monthSelector = new Select(webDriver.findElement(By.id("ddlMonth")));
+			Select seriesSelector = new Select(webDriver.findElement(By.id("ddlSeries")));
 
-            String currentDate = null;
-            for (Element schedule : baseballSchedules) {
-                Element date = schedule.selectFirst("td.day");
-                Element time = schedule.selectFirst("td.time");
-                Element awayTeamElement = schedule.selectFirst("td.play > span");
-                Element homeTeamElement = schedule.selectFirst("td.play > span:nth-child(3)");
+			for (int i = 0; i < 2; i++) {
+				seriesSelector.selectByIndex(i);
 
-                if (date != null && (currentDate == null || !currentDate.equals(date.text()))) {
-                    currentDate = date.text();
-                }
+				for (int j = 2; j < 12; j++) {
+					if (i == 0 && j > 2) {
+						break;
+					}
+					monthSelector.selectByIndex(j);
 
-                if (time != null) {
-                    LocalDateTime startedAt = CustomDateUtil.toDateTime(year + "-" + currentDate.substring(0, 5).replace(".", "-") + " " + time.text());
-                    Team homeTeam = teamRepository.findByShortName(homeTeamElement.text()).orElseThrow();
-                    Team awayTeam = teamRepository.findByShortName(awayTeamElement.text()).orElseThrow();
+					Document doc = Jsoup.parse(webDriver.getPageSource());
+					Elements baseballSchedules = doc.select("#tblScheduleList > tbody > tr");
 
-                    Game game = Game.builder()
-                            .homeTeam(homeTeam)
-                            .awayTeam(awayTeam)
-                            .startedAt(startedAt.plusMonths(8).plusDays(14))
-                            .status(Status.READY)
-                            .homeTeamScore(0)
-                            .awayTeamScore(0)
-                            .build();
-                    
-                    gameRepository.save(game);
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            webDriver.quit();
-        }
-    }
+					this.currentDate = null;
+
+					for (Element schedule : baseballSchedules) {
+						addGameScheduleByDay(schedule, year);
+					}
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			webDriver.quit();
+		}
+	}
+
+	public void updateGameScore() {
+		WebDriver webDriver = WebDriverUtil.getChromeDriver();
+		try {
+			webDriver.get("https://www.koreabaseball.com/Schedule/GameCenter/Main.aspx");
+			Document doc = Jsoup.parse(webDriver.getPageSource());
+			String gameDate = doc.select("ul[class=date]")
+				.select("li[class=today]")
+				.text()
+				.replace(".", "-")
+				.substring(0, 10);
+
+			Elements gameElements = doc.select("ul[class=game-list-n]")
+				.select("li[g_dt=" + gameDate.replace("-", "") + "]");
+
+			for (Element gameElement : gameElements) {
+				try {
+					String status = gameElement.className().split("-")[1];
+					String gameTime = gameElement.select("div[class=top]").select("ul > li:nth-child(2)").text();
+					Team homeTeam = teamRepository.findByShortName(gameElement.attributes().get("home_nm"))
+						.orElseThrow();
+					Team awayTeam = teamRepository.findByShortName(gameElement.attributes().get("away_nm"))
+						.orElseThrow();
+					Elements teamElements = gameElement.select("div[class=middle]").select("div[class=info]");
+					String homeScoreStr = teamElements.select("div[class=team home]").select("div:nth-child(2)").text();
+					String awayScoreStr = teamElements.select("div[class=team away]").select("div:nth-child(2)").text();
+					int homeScore = Integer.parseInt(
+						homeScoreStr.isEmpty() ? "0" : homeScoreStr);
+					int awayScore = Integer.parseInt(
+						awayScoreStr.isEmpty() ? "0" : awayScoreStr);
+
+					LocalDateTime startedAt = CustomDateUtil.toDateTime(gameDate + " " + gameTime);
+
+					Game game = gameRepository.findByHomeTeamAndAwayTeamAndStartedAt(homeTeam, awayTeam, startedAt)
+						.orElseThrow();
+
+					Status newStatus = Status.findByName(status);
+
+					game.updateByScrapeData(homeScore, awayScore, newStatus);
+				} catch (Exception e) {
+					continue;
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			webDriver.quit();
+		}
+	}
+
+	@Transactional(readOnly = true)
+	private void addGameScheduleByDay(Element schedule, String year) {
+		Element date = schedule.selectFirst("td.day");
+		Element time = schedule.selectFirst("td.time");
+		Element awayTeamElement = schedule.selectFirst("td.play > span");
+		Element homeTeamElement = schedule.selectFirst("td.play > span:nth-child(3)");
+
+		if (date != null && (currentDate == null || !currentDate.equals(date.text()))) {
+			currentDate = date.text();
+		}
+
+		if (time != null) {
+			LocalDateTime startedAt = CustomDateUtil.toDateTime(
+				year + "-" + currentDate.substring(0, 5).replace(".", "-") + " " + time.text());
+			Team homeTeam = teamRepository.findByShortName(homeTeamElement.text()).orElseThrow();
+			Team awayTeam = teamRepository.findByShortName(awayTeamElement.text()).orElseThrow();
+
+			addGame(homeTeam, awayTeam, startedAt);
+		}
+	}
+
+	private void addGame(Team homeTeam, Team awayTeam, LocalDateTime startedAt) {
+		Game game = Game.builder()
+			.homeTeam(homeTeam)
+			.awayTeam(awayTeam)
+			.startedAt(startedAt)
+			.status(Status.READY)
+			.homeTeamScore(0)
+			.awayTeamScore(0)
+			.build();
+
+		gameRepository.save(game);
+	}
 }


### PR DESCRIPTION
1. 경기 상태, 스코어 크롤링 서비스 구현
  - KBO 홈페이지의 게임 센터 페이지 크롤링하여 경기 상태 및 스코어 업데이트하는 서비스 구현
  
2. 해당 서비스 스케줄러 등록
  - 평일, 주말 구분하여 스케줄 추가
  - 평일 : 18시 ~ 23시까지 10분 단위로 스케줄러 동작
  - 주말 : 13시 ~ 23시까지 10분 단위로 스케줄러 동작