### PR TITLE
선물내역 조회 시, 프로필 이미지가 아닌 응원하는 팀 팀명 응답하도록 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/dto/MemberResponse.java
@@ -51,13 +51,13 @@ public class MemberResponse {
 	@AllArgsConstructor
 	public static class GiftHistoryDTO {
 		private String nickname;
-		private String profileImageUrl;
+		private String teamName;
 		private int token;
 		private String takeDate;
 
 		public GiftHistoryDTO(GiftToken giftToken) {
 			this.nickname = giftToken.getTakeMember().getNickname();
-			this.profileImageUrl = giftToken.getTakeMember().getProfileImageUrl();
+			this.teamName = giftToken.getTakeMember().getTeam().getName();
 			this.token = giftToken.getTokenAmount();
 			this.takeDate = CustomDateUtil.dateToString(giftToken.getCreatedAt());
 		}


### PR DESCRIPTION
closed #165 

- MemberResponse.GiftHistoryDTO 필드 수정