### PR TITLE
Refactor: 채팅방 투표 완료 시에만 채팅방 입장 가능 & 게임이 종료 된 뒤 session 삭제 스케줄러 작업

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
@@ -53,13 +53,10 @@ public class ChatService {
         sessions.remove(sessionId);
     }
     
-    @Scheduled(cron = "0 0/20 2 * * ?", zone = "Asia/Seoul")
+    //@Scheduled(cron = "0 0/20 2 * * ?", zone = "Asia/Seoul")
+    @Scheduled(fixedDelay = 60000)
 	public void removeSessionForEndedGames() {
 		List<Long> endedGameIds = gameRepository.findGameIdsByStatus(Status.END);
-		
-		if (endedGameIds == null || endedGameIds.isEmpty()) {
-		    return;
-		}
 		
 		endedGameIds.forEach(gameId -> {
 		    String gameIdString = String.valueOf(gameId);

--- a/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
@@ -2,12 +2,17 @@ package com.example.baseballprediction.domain.chat.service;
 
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import com.example.baseballprediction.domain.game.repository.GameRepository;
 import com.example.baseballprediction.global.constant.ErrorCode;
+import com.example.baseballprediction.global.constant.Status;
 import com.example.baseballprediction.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +26,7 @@ public class ChatService {
     private Map<String, Set<String>> chatRooms = new ConcurrentHashMap<>();
     //클라이언트가 예기치 못하게게 끊겼을 경우 
     private ConcurrentHashMap<String, String> sessions = new ConcurrentHashMap<>();
+    private final GameRepository gameRepository;
     
     // 사용자가 채팅방에 입장할 때 호출됨
     public void addChatRoom(String sessionId, String gameId) {
@@ -46,4 +52,18 @@ public class ChatService {
     public void removeSession(String sessionId) {
         sessions.remove(sessionId);
     }
+    
+    @Scheduled(cron = "0 0/20 2 * * ?", zone = "Asia/Seoul")
+	public void removeSessionForEndedGames() {
+		List<Long> endedGameIds = gameRepository.findGameIdsByStatus(Status.END);
+		
+		if (endedGameIds == null || endedGameIds.isEmpty()) {
+		    return;
+		}
+		
+		endedGameIds.forEach(gameId -> {
+		    String gameIdString = String.valueOf(gameId);
+		    closeChatRoom(gameIdString);
+		});
+	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/gamevote/repository/GameVoteRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/gamevote/repository/GameVoteRepository.java
@@ -22,4 +22,5 @@ public interface GameVoteRepository extends JpaRepository<GameVote, Long> {
 			+ " where game_id =:gameId", nativeQuery = true)
 	Optional<GameVoteRatioDTO> findVoteRatio(@Param("homeTeamid") int homeTeamid, @Param("awayTeamid") int awayTeamid, @Param("gameId") Long gameId);
 	
+	boolean existsByGameIdAndMemberId(Long gameId, Long memberId);
 }

--- a/src/main/java/com/example/baseballprediction/global/stomp/handler/StompHandler.java
+++ b/src/main/java/com/example/baseballprediction/global/stomp/handler/StompHandler.java
@@ -75,11 +75,11 @@ public class StompHandler implements ChannelInterceptor {
             
         }
 
-		boolean gameVoteExists = gameVoteRepository.existsByGameIdAndMemberId(Long.parseLong(gameId), memberId);
-		
-		if (!gameVoteExists) {
-		    return createErrorMessage(accessor.getSessionId(), "투표 완료 후 채팅방에 입장 할 수 있습니다.");
-		}
+        boolean gameVoteExists = gameVoteRepository.existsByGameIdAndMemberId(Long.parseLong(gameId), memberId);
+	
+        if (!gameVoteExists) {
+        	return createErrorMessage(accessor.getSessionId(), "투표 완료 후 채팅방에 입장 할 수 있습니다.");
+        }
         
         MemberDetails memberDetails = createMemberDetails(memberId);
         if (accessor.getSessionAttributes() == null) {


### PR DESCRIPTION
Refactor: 채팅방 투표 완료 시에만 채팅방 입장 가능 & 게임이 종료 된 뒤
session 삭제 스케줄러 작업

- StompHandler : 채팅방 투표 완료 후 입장 가능 로직 추가
- GameVoteRepository : gameVote 테이블에서 사용자가 투표를 했는지 안
  했는지 체크
- ChatService : game상태가 end일시 남아 있는 gameId에 대한 세션 삭제

Ref: #161 