### PR TITLE
SockJS 사용 시, 웹소켓 연결 오류 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/baseballprediction/global/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
 				new AntPathRequestMatcher("/health"),
 				new AntPathRequestMatcher("/games"),
 				new AntPathRequestMatcher("/games/daily-replies"),
-				new AntPathRequestMatcher("/chat")
+				new AntPathRequestMatcher("/chat/**")
 			).permitAll()
 			.anyRequest().authenticated());
 


### PR DESCRIPTION
closed #173 

- SockJS 클라이언트는 서버의 기본 정보를 얻기 위해 GET /info를 호출함
- 기존에는 /chat url만 permitAll을 준 상태여서 SockJS를 사용하면 해당 /info url이 인가 체크에 걸려서 연결 실패하는게 원인
- /chat/** url에 대해 permitAll을 줘서 해결