### PR TITLE
KBO 홈페이지 경기취소 업데이트 안되는 오류 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/global/scrape/service/ScrapeService.java
+++ b/src/main/java/com/example/baseballprediction/global/scrape/service/ScrapeService.java
@@ -91,8 +91,13 @@ public class ScrapeService {
 					Team awayTeam = teamRepository.findByShortName(gameElement.attributes().get("away_nm"))
 						.orElseThrow();
 					Elements teamElements = gameElement.select("div[class=middle]").select("div[class=info]");
-					String homeScoreStr = teamElements.select("div[class=team home]").select("div:nth-child(2)").text();
-					String awayScoreStr = teamElements.select("div[class=team away]").select("div:nth-child(2)").text();
+					String homeScoreStr = "0";
+					String awayScoreStr = "0";
+
+					if (!status.equals(Status.CANCEL.getName())) {
+						homeScoreStr = teamElements.select("div[class=team home]").select("div:nth-child(2)").text();
+						awayScoreStr = teamElements.select("div[class=team away]").select("div:nth-child(2)").text();
+					}
 					int homeScore = Integer.parseInt(
 						homeScoreStr.isEmpty() ? "0" : homeScoreStr);
 					int awayScore = Integer.parseInt(


### PR DESCRIPTION
closed #179 

- 경기취소된 경기는 스코어 태그가 없어서 스코어 크롤링 시, String값이 들어옴
- 따라서, parseInt()에서 오류가 발생하여 경기상태가 cancel일 경우, 스코어를 0으로 고정하도록 분기 처리