### PR TITLE
소셜 로그인 시, 엑세스 토큰 쿼리 파라미터로 전달

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/gifttoken/entity/GiftToken.java
+++ b/src/main/java/com/example/baseballprediction/domain/gifttoken/entity/GiftToken.java
@@ -2,6 +2,7 @@ package com.example.baseballprediction.domain.gifttoken.entity;
 
 import com.example.baseballprediction.domain.BaseEntity;
 import com.example.baseballprediction.domain.member.entity.Member;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -38,13 +39,16 @@ public class GiftToken extends BaseEntity {
 
 	@Column(nullable = false)
 	private int tokenAmount;
-	
+
+	@Column(length = 100)
+	private String comment;
+
 	@Builder
-	public GiftToken(Member takeMember, Member giveMember, int tokenAmount) {
-        this.takeMember = takeMember;
-        this.giveMember = giveMember;
-        this.tokenAmount = tokenAmount;
-    }
-	
-	
+	public GiftToken(Member takeMember, Member giveMember, int tokenAmount, String comment) {
+		this.takeMember = takeMember;
+		this.giveMember = giveMember;
+		this.tokenAmount = tokenAmount;
+		this.comment = comment;
+	}
+
 }

--- a/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/controller/MemberController.java
@@ -29,6 +29,7 @@ import com.example.baseballprediction.global.constant.ErrorCode;
 import com.example.baseballprediction.global.error.exception.BusinessException;
 import com.example.baseballprediction.global.security.MemberDetails;
 import com.example.baseballprediction.global.security.jwt.JwtTokenProvider;
+import com.example.baseballprediction.global.security.oauth.dto.OAuthResponse;
 import com.example.baseballprediction.global.util.ApiResponse;
 
 import jakarta.validation.Valid;
@@ -144,6 +145,17 @@ public class MemberController {
 			nickname);
 
 		ApiResponse<MemberResponse.NicknameDTO> response = ApiResponse.success(responseDTO);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/login/success")
+	public ResponseEntity<ApiResponse<OAuthResponse.LoginDTO>> oauth2LoginSuccess(
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		OAuthResponse.LoginDTO loginDTO = memberService.oauth2Login(memberDetails.getMember().getUsername());
+
+		ApiResponse<OAuthResponse.LoginDTO> response = ApiResponse.success(loginDTO);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/example/baseballprediction/domain/member/entity/Member.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/entity/Member.java
@@ -71,7 +71,7 @@ public class Member extends BaseEntity {
 	@Transient
 	private int loseFairyCount;
 
-	@Transient
+	@Column(nullable = false)
 	private boolean isNewMember;
 
 	@Transient
@@ -117,8 +117,8 @@ public class Member extends BaseEntity {
 	public void setVoteRatio(int voteRatio) {
 		this.voteRatio = voteRatio;
 	}
-	
+
 	public void addToken(int token) {
-        this.token += token;
+		this.token += token;
 	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/service/MemberService.java
@@ -32,6 +32,7 @@ import com.example.baseballprediction.global.constant.ImageType;
 import com.example.baseballprediction.global.error.exception.BusinessException;
 import com.example.baseballprediction.global.error.exception.NotFoundException;
 import com.example.baseballprediction.global.security.jwt.JwtTokenProvider;
+import com.example.baseballprediction.global.security.oauth.dto.OAuthResponse;
 import com.example.baseballprediction.global.util.S3UploadService;
 
 import lombok.RequiredArgsConstructor;
@@ -91,6 +92,10 @@ public class MemberService {
 			ImageType.PROFILE);
 
 		member.updateDetails(uploadFileName, detailsDTO.getNickname(), detailsDTO.getComment());
+
+		if (member.isNewMember()) {
+			member.setIsNewMember(false);
+		}
 	}
 
 	@Transactional(readOnly = true)
@@ -194,5 +199,15 @@ public class MemberService {
 			.comment(chatGiftRequestDTO.getComment())
 			.build();
 		giftTokenRepository.save(giftToken);
+	}
+
+	public OAuthResponse.LoginDTO oauth2Login(String username) {
+		Member member = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+		String teamName = member.getTeam() == null ? null : member.getTeam().getName();
+
+		return new OAuthResponse.LoginDTO(member.isNewMember(), member.getProfileImageUrl(), member.getNickname(),
+			teamName);
 	}
 }

--- a/src/main/java/com/example/baseballprediction/global/security/MemberDetails.java
+++ b/src/main/java/com/example/baseballprediction/global/security/MemberDetails.java
@@ -9,15 +9,14 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import com.example.baseballprediction.domain.member.entity.Member;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
 public class MemberDetails implements UserDetails, OAuth2User {
 	private final Member member;
 
 	private Map<String, Object> attributes;
+
+	public MemberDetails(Member member) {
+		this.member = member;
+	}
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -71,8 +70,16 @@ public class MemberDetails implements UserDetails, OAuth2User {
 	public String getProfileImageUrl() {
 		return member.getProfileImageUrl();
 	}
-	
+
 	public Integer getTeamId() {
 		return member.getTeam().getId();
+	}
+
+	public Member getMember() {
+		return this.member;
+	}
+
+	public Map<String, Object> getAttributes() {
+		return this.attributes;
 	}
 }

--- a/src/main/java/com/example/baseballprediction/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/baseballprediction/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,19 +1,15 @@
 package com.example.baseballprediction.global.security.oauth.handler;
 
-import static com.example.baseballprediction.global.security.oauth.dto.OAuthResponse.*;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.example.baseballprediction.global.security.MemberDetails;
 import com.example.baseballprediction.global.security.jwt.JwtTokenProvider;
-import com.example.baseballprediction.global.util.ApiResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,24 +23,27 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
-		ObjectMapper objectMapper = new ObjectMapper();
+		// ObjectMapper objectMapper = new ObjectMapper();
 		MemberDetails memberDetails = (MemberDetails)authentication.getPrincipal();
 		String token = JwtTokenProvider.createToken(memberDetails.getMember());
 
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		// response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		// response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		//
+		// response.addHeader(JwtTokenProvider.HEADER, token);
 
-		response.addHeader(JwtTokenProvider.HEADER, token);
+		// boolean isNewMember = memberDetails.isNewMember();
+		// String teamName =
+		// 	memberDetails.getMember().getTeam() == null ? null : memberDetails.getMember().getTeam().getName();
+		// LoginDTO loginDTO = new LoginDTO(isNewMember, memberDetails.getProfileImageUrl(), memberDetails.getName(),
+		// 	teamName);
 
-		boolean isNewMember = memberDetails.isNewMember();
-		String teamName =
-			memberDetails.getMember().getTeam() == null ? null : memberDetails.getMember().getTeam().getName();
-		LoginDTO loginDTO = new LoginDTO(isNewMember, memberDetails.getProfileImageUrl(), memberDetails.getName(),
-			teamName);
+		String targetUrl = UriComponentsBuilder.fromUriString(request.getRequestURI())
+			.queryParam("accessToken", token)
+			.build()
+			.encode(StandardCharsets.UTF_8)
+			.toUriString();
 
-		ApiResponse<LoginDTO> apiResponse = ApiResponse.success(loginDTO);
-
-		String body = objectMapper.writeValueAsString(apiResponse);
-		response.getWriter().write(body);
+		response.sendRedirect(targetUrl);
 	}
 }

--- a/src/main/java/com/example/baseballprediction/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/baseballprediction/global/security/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -29,7 +29,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		Authentication authentication) throws IOException, ServletException {
 		ObjectMapper objectMapper = new ObjectMapper();
 		MemberDetails memberDetails = (MemberDetails)authentication.getPrincipal();
-		String token = JwtTokenProvider.createToken(memberDetails.getUsername());
+		String token = JwtTokenProvider.createToken(memberDetails.getMember());
 
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.setCharacterEncoding(StandardCharsets.UTF_8.name());

--- a/src/main/resources/h2/data.sql
+++ b/src/main/resources/h2/data.sql
@@ -9,15 +9,15 @@ insert into team(name, short_name, color, created_at) values ('삼성 라이온�
 insert into team(name, short_name, color, created_at) values ('한화 이글스', '한화', '', current_timestamp);
 insert into team(name, short_name, color, created_at) values ('키움 히어로즈', '키움', '', current_timestamp);
 
-insert into member(username, social, password, nickname, team_id, token, level, created_at) values
-('playdot1', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저1', 1, 0, 1, current_timestamp),
-('playdot2', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저2', 3, 0, 1, current_timestamp),
-('playdot3', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저3', 4, 0, 1, current_timestamp),
-('playdot4', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저4', 5, 0, 1, current_timestamp),
-('playdot5', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저5', 7, 0, 1, current_timestamp);
+insert into member(username, social, password, nickname, team_id, token, level, is_new_member, created_at) values
+('playdot1', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저1', 1, 0, 1, false, current_timestamp),
+('playdot2', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저2', 3, 0, 1, false, current_timestamp),
+('playdot3', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저3', 4, 0, 1, false, current_timestamp),
+('playdot4', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저4', 5, 0, 1, false, current_timestamp),
+('playdot5', 'KAKAO', '$2a$12$bYyLgOHWLAhfIJ7FwZ3S..ArxyhrKWxdGvK55XFLIyT9p1NNul0aK', '테스트유저5', 7, 0, 1, false, current_timestamp);
 
-INSERT INTO game(away_team_id, away_team_score, home_team_id, home_team_score, win_team_id, game_id, started_at, status) VALUES
-(7, 0, 5, 0, NULL, 1, '2023-12-15 14:00:00', 'READY'),
+insert into game(away_team_id, away_team_score, home_team_id, home_team_score, win_team_id, game_id, started_at, status) values
+(7, 0, 5, 0, null, 1, '2023-12-15 14:00:00', 'READY'),
 (6, 0, 3, 0, NULL, 2,  '2023-12-15 14:00:00', 'READY'),
 (4, 0, 8, 0, NULL, 3,  '2023-12-15 14:00:00', 'READY'),
 (1, 0, 2, 0, NULL, 4,  '2023-12-15 14:00:00', 'READY'),
@@ -79,8 +79,8 @@ INSERT INTO game(away_team_id, away_team_score, home_team_id, home_team_score, w
 (6, 0, 10, 0, NULL, 60,  '2023-12-28 18:30:00', 'READY'),
 (5, 0, 1, 0, NULL, 61,  '2023-12-29 17:00:00', 'READY'),
 (4, 0, 3, 0, NULL, 62,  '2023-12-29 17:00:00', 'READY');
-INSERT INTO game(away_team_id, away_team_score, home_team_id, home_team_score, win_team_id, game_id, started_at, status) values
-(7, 0, 8, 0, NULL, 63,  '2023-12-29 17:00:00', 'READY'),
+insert into game(away_team_id, away_team_score, home_team_id, home_team_score, win_team_id, game_id, started_at, status) values
+(7, 0, 8, 0, null, 63,  '2023-12-29 17:00:00', 'READY'),
 (9, 0, 2, 0, NULL, 64,  '2023-12-29 17:00:00', 'READY'),
 (6, 0, 10, 0, NULL, 65,  '2023-12-29 17:00:00', 'READY'),
 (5, 0, 1, 0, NULL, 66,  '2023-12-30 14:00:00', 'READY'),
@@ -143,15 +143,15 @@ INSERT INTO game(away_team_id, away_team_score, home_team_id, home_team_score, w
 (10, 0, 7, 0, NULL, 123,  '2024-01-12 17:00:00', 'READY'),
 (8, 0, 2, 0, NULL, 124,  '2024-01-12 17:00:00', 'READY');
 
-INSERT INTO game(away_team_id, away_team_score, home_team_id, home_team_score, win_team_id, game_id, started_at, status) values
-(4, 0, 9, 0, NULL, 125,  '2024-01-12 17:00:00', 'READY'),
+insert into game(away_team_id, away_team_score, home_team_id, home_team_score, win_team_id, game_id, started_at, status) values
+(4, 0, 9, 0, null, 125,  '2024-01-12 17:00:00', 'READY'),
 (6, 0, 1, 0, NULL, 126,  '2024-01-13 14:00:00', 'READY'),
 (5, 0, 3, 0, NULL, 127,  '2024-01-13 14:00:00', 'READY'),
 (10, 0, 7, 0, NULL, 128,  '2024-01-13 14:00:00', 'READY'),
 (8, 0, 2, 0, NULL, 129,  '2024-01-13 14:00:00', 'READY'),
 (4, 0, 9, 0, NULL, 130,  '2024-01-13 14:00:00', 'READY');
 
-INSERT INTO monthly_fairy(statistic_month, type, fairy_rank, vote_ratio, member_id) VALUES
+insert into monthly_fairy(statistic_month, type, fairy_rank, vote_ratio, member_id) values
 (202312, 'WIN', 1, 90, 1),
 (202312, 'LOSE', 1, 10, 5),
 (202312, 'WIN', 2, 75, 2),

--- a/src/main/resources/h2/schema.sql
+++ b/src/main/resources/h2/schema.sql
@@ -18,6 +18,7 @@ create table member (
     member_comment varchar(100),
 	token int default 0 not null,
     level int default 1 not null,
+    is_new_member tinyint(1) not null,
 	created_at datetime not null default current_timestamp,
     modified_at datetime,
     foreign key(team_id) references team(team_id)


### PR DESCRIPTION
임시방편으로 엑세스 토큰을 쿼리 파라미터로 전달하여 클라이언트 쪽에서 전달받을 수 있도록 수정

추후에 springboot oauth2-client 의존성 제거하고 직접 구현하여 원하는 동작을 할 수 있도록 해야함