### PR TITLE
오늘의 승부예측 댓글 조회 API, 비로그인 시 NPE 오류 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/game/controller/GameController.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/controller/GameController.java
@@ -23,7 +23,6 @@ import com.example.baseballprediction.domain.game.dto.GameResponse.GameDtoDaily;
 import com.example.baseballprediction.domain.game.service.GameService;
 import com.example.baseballprediction.domain.gamevote.dto.GameVoteRequest.GameVoteRequestDTO;
 import com.example.baseballprediction.domain.gamevote.service.GameVoteService;
-import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.domain.reply.dto.ReplyRequest;
 import com.example.baseballprediction.domain.reply.dto.ReplyResponse;
 import com.example.baseballprediction.domain.reply.service.ReplyService;
@@ -62,8 +61,10 @@ public class GameController {
 		@RequestParam(required = false, defaultValue = "0") int page,
 		@RequestParam(required = false, defaultValue = "15") int item) {
 
+		String username = memberDetails == null ? null : memberDetails.getUsername();
+
 		Page<ReplyDTO> replyGameList = replyService.findRepliesByType(ReplyType.GAME, page, item,
-			memberDetails.getUsername());
+			username);
 
 		ApiResponse<Page<ReplyDTO>> response = ApiResponse.success(replyGameList);
 
@@ -156,17 +157,17 @@ public class GameController {
 
 		return ResponseEntity.ok(response);
 	}
-	
+
 	@GetMapping("/loginUser")
 	public ResponseEntity<ApiResponse<List<GameDtoDaily>>> gameDailyTodayListForLoggedInUser(
-			@AuthenticationPrincipal MemberDetails memberDetails) {
-	
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
 		List<GameDtoDaily> gameDtoDailyList = gameService.findDailyGame(memberDetails.getMember().getId());
-	
+
 		ApiResponse<List<GameDtoDaily>> response = ApiResponse.success(gameDtoDailyList);
-	
+
 		return ResponseEntity.ok(response);
-	
-	}	
+
+	}
 
 }


### PR DESCRIPTION
closed #192 

- memberDetails = null일 때, getUsername() 메서드 호출 시, NPE 발생하여 해당 오류 수정
- 댓글 조회 시, 좋아요 수 제대로 표시 안되는 오류 수정