### PR TITLE
경기 종료 시, 채팅방 세션 삭제 로직 수정 (AOP 적용)

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
+++ b/src/main/java/com/example/baseballprediction/domain/chat/service/ChatService.java
@@ -1,64 +1,50 @@
 package com.example.baseballprediction.domain.chat.service;
 
-
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.example.baseballprediction.domain.game.repository.GameRepository;
 import com.example.baseballprediction.global.constant.ErrorCode;
-import com.example.baseballprediction.global.constant.Status;
 import com.example.baseballprediction.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
-
 @RequiredArgsConstructor
 @Service
 public class ChatService {
-	
+
 	// 채팅방 ID와 그 채팅방에 참여중인 사용자 세션 ID의 맵핑
-    private Map<Long, Set<String>> chatRooms = new ConcurrentHashMap<>();
-    //클라이언트가 예기치 못하게게 끊겼을 경우 
-    private ConcurrentHashMap<String, String> sessions = new ConcurrentHashMap<>();
-    private final GameRepository gameRepository;
-    
-    // 사용자가 채팅방에 입장할 때 호출됨
-    public void addChatRoom(String sessionId, Long gameId) {
-        // 채팅방이 존재하지 않으면 새로 생성
-        chatRooms.putIfAbsent(gameId, new HashSet<>());
-        // 해당 채팅방에 클라이언트 세션 추가
-        chatRooms.get(gameId).add(sessionId);
-    }
-    
-    public void removeMembeSessionChatRoom(String webSocketSessionId, Long gameId) {
-        Set<String> sessions = chatRooms.get(gameId);
-        if (sessions == null) {
-        	throw new NotFoundException(ErrorCode.MEMBER_NOT_FOUND);
-        }
-        sessions.remove(webSocketSessionId);
-    }
-    
-    // 채팅방의 모든 사용자 세션을 종료하는 메서드
-    public void closeChatRoom(Long gameId) {
-    	chatRooms.remove(gameId);
-    }
-    
-    public void removeSession(String sessionId) {
-        sessions.remove(sessionId);
-    }
-    
-    @Scheduled(cron = "0 0/20 2 * * ?", zone = "Asia/Seoul")
-	public void removeSessionForEndedGames() {
-		List<Long> endedGameIds = gameRepository.findGameIdsByStatus(Status.END);
-		
-		endedGameIds.forEach(gameId -> {
-		    closeChatRoom(gameId);
-		});
+	private Map<Long, Set<String>> chatRooms = new ConcurrentHashMap<>();
+	//클라이언트가 예기치 못하게게 끊겼을 경우
+	private ConcurrentHashMap<String, String> sessions = new ConcurrentHashMap<>();
+	private final GameRepository gameRepository;
+
+	// 사용자가 채팅방에 입장할 때 호출됨
+	public void addChatRoom(String sessionId, Long gameId) {
+		// 채팅방이 존재하지 않으면 새로 생성
+		chatRooms.putIfAbsent(gameId, new HashSet<>());
+		// 해당 채팅방에 클라이언트 세션 추가
+		chatRooms.get(gameId).add(sessionId);
+	}
+
+	public void removeMembeSessionChatRoom(String webSocketSessionId, Long gameId) {
+		Set<String> sessions = chatRooms.get(gameId);
+		if (sessions == null) {
+			throw new NotFoundException(ErrorCode.MEMBER_NOT_FOUND);
+		}
+		sessions.remove(webSocketSessionId);
+	}
+
+	// 채팅방의 모든 사용자 세션을 종료하는 메서드
+	public void closeChatRoom(Long gameId) {
+		chatRooms.remove(gameId);
+	}
+
+	public void removeSession(String sessionId) {
+		sessions.remove(sessionId);
 	}
 }

--- a/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
@@ -7,7 +7,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.example.baseballprediction.domain.chat.service.ChatService;
 import com.example.baseballprediction.domain.game.dto.GameResponse;
 import com.example.baseballprediction.domain.game.dto.GameResponse.GameDtoDaily;
 import com.example.baseballprediction.domain.game.dto.GameVoteProjection;
@@ -17,6 +19,7 @@ import com.example.baseballprediction.domain.gamevote.dto.GameVoteRatioDTO;
 import com.example.baseballprediction.domain.gamevote.repository.GameVoteRepository;
 import com.example.baseballprediction.domain.member.entity.Member;
 import com.example.baseballprediction.domain.member.repository.MemberRepository;
+import com.example.baseballprediction.domain.team.entity.Team;
 import com.example.baseballprediction.global.constant.ErrorCode;
 import com.example.baseballprediction.global.error.exception.NotFoundException;
 import com.example.baseballprediction.global.util.CustomDateUtil;
@@ -31,6 +34,8 @@ public class GameService {
 	private final GameVoteRepository gameVoteRepository;
 	private final MemberRepository memberRepository;
 
+	private final ChatService chatService;
+
 	public List<GameDtoDaily> findDailyGame(Long memberId) {
 		List<Game> games = gameRepository.findAll();
 
@@ -43,17 +48,19 @@ public class GameService {
 			if (gameFormatDate.equals(formatDate)) {
 				GameVoteRatioDTO gameVoteRatioDTO = gameVoteRepository.findVoteRatio(game.getHomeTeam().getId(),
 					game.getAwayTeam().getId(), game.getId()).orElseThrow();
-				
+
 				boolean homeTeamHasVoted = false;
 				boolean awayTeamHasVoted = false;
-				
-				if(memberId != null) {
-					homeTeamHasVoted = gameVoteRepository.existsByGameIdAndTeamIdAndMemberId(game.getId(), game.getHomeTeam().getId(), memberId);
-					awayTeamHasVoted = gameVoteRepository.existsByGameIdAndTeamIdAndMemberId(game.getId(), game.getAwayTeam().getId(), memberId);
+
+				if (memberId != null) {
+					homeTeamHasVoted = gameVoteRepository.existsByGameIdAndTeamIdAndMemberId(game.getId(),
+						game.getHomeTeam().getId(), memberId);
+					awayTeamHasVoted = gameVoteRepository.existsByGameIdAndTeamIdAndMemberId(game.getId(),
+						game.getAwayTeam().getId(), memberId);
 				}
 
 				GameDtoDaily dailygame = new GameDtoDaily(game, game.getHomeTeam(), game.getAwayTeam(),
-					gameVoteRatioDTO,homeTeamHasVoted, awayTeamHasVoted);
+					gameVoteRatioDTO, homeTeamHasVoted, awayTeamHasVoted);
 
 				gameDTOList.add(dailygame);
 
@@ -87,6 +94,11 @@ public class GameService {
 		}
 
 		return gameResults;
+	}
+
+	@Transactional
+	public void updateWinTeam(Game game, Team team) {
+		game.updateWinTeam(team);
 	}
 
 }

--- a/src/main/java/com/example/baseballprediction/global/aspect/ChatAspect.java
+++ b/src/main/java/com/example/baseballprediction/global/aspect/ChatAspect.java
@@ -1,0 +1,25 @@
+package com.example.baseballprediction.global.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.example.baseballprediction.domain.chat.service.ChatService;
+import com.example.baseballprediction.domain.game.entity.Game;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class ChatAspect {
+	private final ChatService chatService;
+
+	@AfterReturning("execution(* com.example.baseballprediction.domain.game..*Service.updateWinTeam(..))")
+	public void removeChatRoomSession(JoinPoint joinPoint) {
+		Game game = (Game)joinPoint.getArgs()[0];
+
+		chatService.closeChatRoom(game.getId());
+	}
+}


### PR DESCRIPTION
closed #194 

- 기존 스케쥴러로 종료된 경기를 순회하면서 채팅방 세션 삭제하던 로직을 AOP로 수정함
- GameService.updateWinTeam 메서드가 정상 실행되면 채팅방 세션 삭제 메서드가 동작하도록 구현