### PR TITLE
fix : 마이페이지 요정 히스토리 조회 API 오류 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/member/dto/FairyProjection.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/dto/FairyProjection.java
@@ -1,7 +1,7 @@
 package com.example.baseballprediction.domain.member.dto;
 
 public interface FairyProjection {
-	int getRank();
+	int getTotalRank();
 
 	String getTitle();
 

--- a/src/main/java/com/example/baseballprediction/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/baseballprediction/domain/member/repository/MemberRepository.java
@@ -27,7 +27,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	@Query(
 		value =
-			"select row_number() over(order by count desc) as rank, case when type = 'WIN' then '승리요정' else '패배요정' end || ' ' || fairy_rank || '등' as title, count"
+			"select row_number() over(order by count desc) as totalRank, case when type = 'WIN' then '승리요정' else '패배요정' end || ' ' || fairy_rank || '등' as title, count"
 				+ "  from (select type, fairy_rank, count(*) as count "
 				+ "  from monthly_fairy "
 				+ " where member_id = :memberId "


### PR DESCRIPTION
closed #219 

- MemberRepository.findFairyStatistics() -> rank 컬럼이 mySQL 예약어 중복으로 인해 syntax 관련 예외 발생
- rank -> totalRank 로 컬럼명 변경
- FairyProjection.getRank() -> getTotalRank() 변경