### PR TITLE
REST Docs 의존성 추가 및 환경설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.6'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'jacoco'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.example'
@@ -21,6 +22,8 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    asciidoctorExt
 }
 
 repositories {
@@ -66,6 +69,10 @@ dependencies {
 
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    //REST Docs
+    implementation 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('bootBuildImage') {
@@ -75,6 +82,33 @@ tasks.named('bootBuildImage') {
 tasks.named('test') {
     finalizedBy 'jacocoTestReport'
     useJUnitPlatform()
+}
+
+ext {
+    snippetDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetDir
+}
+
+asciidoctor {
+    inputs.dir snippetDir
+    configurations 'asciidoctorExt'
+
+    sources {
+        include("**/index.adoc")
+    }
+
+    baseDirFollowsSourceFile()
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 jar {


### PR DESCRIPTION
closed #240 

1. 의존성 추가
- spring-restdocs-asciidoctor
- spring-restdocs-mockmvc

2. 빌드 설정
- adoc 생성 경로 : build/generated-snippets
- 문서 생성 경로 : build/docs