### PR TITLE
지난 승부예측 조회 시, 날짜순으로 정렬 안되는 문제 수정

### DIFF
--- a/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
+++ b/src/main/java/com/example/baseballprediction/domain/game/service/GameService.java
@@ -117,11 +117,10 @@ public class GameService {
 		Map<String, List<GameResponse.PastGameDTO>> groupedByDate = gameResults.stream()
 			.collect(Collectors.groupingBy(GameResponse.PastGameDTO::getGameDate));
 
-		List<GameResponse.PastGamesDTO> result = new ArrayList<>();
-
-		for (List<GameResponse.PastGameDTO> games : groupedByDate.values()) {
-			result.add(new GameResponse.PastGamesDTO(games));
-		}
+		List<GameResponse.PastGamesDTO> result = groupedByDate.entrySet().stream()
+			.sorted(Map.Entry.comparingByKey()) // 날짜순으로 정렬
+			.map(entry -> new GameResponse.PastGamesDTO(entry.getValue()))
+			.collect(Collectors.toList());
 
 		return result;
 	}


### PR DESCRIPTION
closed #280 

- List<DTO>로 최종 변환할 때, 정렬 한번 더 하도록 추가